### PR TITLE
feat(rest): auth improvements

### DIFF
--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -21,7 +21,7 @@
     "credo-rest": "bin/credo-rest.js"
   },
   "scripts": {
-    "tsoa": "tsoa spec-and-routes",
+    "tsoa": "ts-node ./scripts/generate-spec-and-routes.ts",
     "dev": "yarn tsoa && tsnd --respawn samples/sampleWithApp.ts",
     "sample": "yarn tsoa && tsnd --respawn samples/sample.ts",
     "sample:with-app": "yarn tsoa && tsnd --respawn samples/sampleWithApp.ts",

--- a/packages/rest/scripts/generate-spec-and-routes.ts
+++ b/packages/rest/scripts/generate-spec-and-routes.ts
@@ -1,0 +1,34 @@
+import { readFile, writeFile } from 'fs/promises'
+import { generateSpecAndRoutes } from 'tsoa'
+
+interface SwaggerJson {
+  paths: {
+    [path: string]: {
+      [method: string]: { parameters?: unknown[]; security?: unknown }
+    }
+  }
+}
+
+async function run() {
+  await generateSpecAndRoutes({})
+
+  // Modify swagger
+  const swaggerJson: SwaggerJson = JSON.parse(await readFile('./src/generated/swagger.json', 'utf-8'))
+
+  for (const [path, pathValue] of Object.entries(swaggerJson.paths)) {
+    for (const [method, methodValue] of Object.entries(pathValue)) {
+      swaggerJson.paths[path][method] = {
+        ...methodValue,
+        parameters: [...(methodValue.parameters ?? []), { $ref: '#/components/parameters/tenant' }],
+        // Removes the security
+        security: undefined,
+      }
+    }
+  }
+
+  await writeFile('./src/generated/swagger.json', JSON.stringify(swaggerJson, null, 2))
+  // eslint-disable-next-line no-console
+  console.log('Successfully generated spec and routes')
+}
+
+run()

--- a/packages/rest/src/controllers/agent/AgentController.ts
+++ b/packages/rest/src/controllers/agent/AgentController.ts
@@ -3,7 +3,7 @@ import type { AgentInfo } from './AgentControllerTypes'
 import { Controller, Example, Get, Request, Route, Security, Tags } from 'tsoa'
 import { injectable } from 'tsyringe'
 
-import { RequestWithRootAgent } from '../../authentication'
+import { RequestWithRootAgent } from '../../tenantMiddleware'
 
 import { agentInfoExample } from './AgentControllerExamples'
 

--- a/packages/rest/src/controllers/anoncreds/AnonCredsController.ts
+++ b/packages/rest/src/controllers/anoncreds/AnonCredsController.ts
@@ -16,7 +16,7 @@ import type {
 import { Body, Controller, Example, Response, Get, Path, Post, Route, Tags, Security, Request } from 'tsoa'
 import { injectable } from 'tsyringe'
 
-import { RequestWithAgent } from '../../authentication'
+import { RequestWithAgent } from '../../tenantMiddleware'
 import { alternativeResponse } from '../../utils/response'
 
 import {

--- a/packages/rest/src/controllers/did/DidsController.ts
+++ b/packages/rest/src/controllers/did/DidsController.ts
@@ -26,7 +26,7 @@ import {
 } from 'tsoa'
 import { injectable } from 'tsyringe'
 
-import { RequestWithAgent } from '../../tenantMiddleware2'
+import { RequestWithAgent } from '../../tenantMiddleware'
 import { alternativeResponse } from '../../utils/response'
 
 import {

--- a/packages/rest/src/controllers/did/DidsController.ts
+++ b/packages/rest/src/controllers/did/DidsController.ts
@@ -26,7 +26,7 @@ import {
 } from 'tsoa'
 import { injectable } from 'tsyringe'
 
-import { RequestWithAgent } from '../../authentication'
+import { RequestWithAgent } from '../../tenantMiddleware2'
 import { alternativeResponse } from '../../utils/response'
 
 import {

--- a/packages/rest/src/controllers/didcomm/basic-messages/BasicMessagesController.ts
+++ b/packages/rest/src/controllers/didcomm/basic-messages/BasicMessagesController.ts
@@ -2,7 +2,7 @@ import { RecordNotFoundError, BasicMessageRole } from '@credo-ts/core'
 import { Body, Controller, Example, Get, Post, Query, Request, Route, Security, Tags } from 'tsoa'
 import { injectable } from 'tsyringe'
 
-import { RequestWithAgent } from '../../../authentication'
+import { RequestWithAgent } from '../../../tenantMiddleware'
 import { apiErrorResponse } from '../../../utils/response'
 import { RecordId, ThreadId } from '../../types'
 

--- a/packages/rest/src/controllers/didcomm/connections/ConnectionsController.ts
+++ b/packages/rest/src/controllers/didcomm/connections/ConnectionsController.ts
@@ -4,7 +4,7 @@ import { DidExchangeState, RecordNotFoundError } from '@credo-ts/core'
 import { Controller, Delete, Example, Get, Path, Post, Query, Request, Route, Security, Tags } from 'tsoa'
 import { injectable } from 'tsyringe'
 
-import { RequestWithAgent } from '../../../authentication'
+import { RequestWithAgent } from '../../../tenantMiddleware'
 import { apiErrorResponse } from '../../../utils/response'
 import { Did } from '../../did/DidsControllerTypes'
 import { RecordId } from '../../types'

--- a/packages/rest/src/controllers/didcomm/credentials/CredentialsController.ts
+++ b/packages/rest/src/controllers/didcomm/credentials/CredentialsController.ts
@@ -8,7 +8,7 @@ import { CredentialState, RecordNotFoundError, CredentialRole } from '@credo-ts/
 import { Body, Controller, Delete, Get, Path, Post, Route, Tags, Example, Query, Security, Request } from 'tsoa'
 import { injectable } from 'tsyringe'
 
-import { RequestWithAgent } from '../../../authentication'
+import { RequestWithAgent } from '../../../tenantMiddleware'
 import { apiErrorResponse } from '../../../utils/response'
 import { RecordId, ThreadId } from '../../types'
 

--- a/packages/rest/src/controllers/didcomm/out-of-band/OutOfBandController.ts
+++ b/packages/rest/src/controllers/didcomm/out-of-band/OutOfBandController.ts
@@ -14,7 +14,7 @@ import { parseMessageType, supportsIncomingMessageType } from '@credo-ts/core/bu
 import { Body, Controller, Delete, Example, Get, Path, Post, Query, Request, Route, Security, Tags } from 'tsoa'
 import { injectable } from 'tsyringe'
 
-import { RequestWithAgent } from '../../../authentication'
+import { RequestWithAgent } from '../../../tenantMiddleware'
 import { apiErrorResponse } from '../../../utils/response'
 import { RecordId } from '../../types'
 import { connectionRecordExample } from '../connections/ConnectionsControllerExamples'

--- a/packages/rest/src/controllers/didcomm/proofs/ProofsController.ts
+++ b/packages/rest/src/controllers/didcomm/proofs/ProofsController.ts
@@ -8,7 +8,7 @@ import { ProofRole, ProofState, RecordNotFoundError } from '@credo-ts/core'
 import { Body, Controller, Delete, Example, Get, Path, Post, Query, Request, Route, Security, Tags } from 'tsoa'
 import { injectable } from 'tsyringe'
 
-import { RequestWithAgent } from '../../../authentication'
+import { RequestWithAgent } from '../../../tenantMiddleware'
 import { apiErrorResponse } from '../../../utils/response'
 import { RecordId, ThreadId } from '../../types'
 

--- a/packages/rest/src/controllers/openid4vc/issuance-sessions/OpenId4VcIssuanceSessionsController.ts
+++ b/packages/rest/src/controllers/openid4vc/issuance-sessions/OpenId4VcIssuanceSessionsController.ts
@@ -9,7 +9,7 @@ import { OpenId4VcIssuanceSessionRepository } from '@credo-ts/openid4vc/build/op
 import { Body, Controller, Delete, Example, Get, Path, Post, Query, Request, Route, Security, Tags } from 'tsoa'
 import { injectable } from 'tsyringe'
 
-import { RequestWithAgent } from '../../../authentication'
+import { RequestWithAgent } from '../../../tenantMiddleware'
 import { apiErrorResponse } from '../../../utils/response'
 import { PublicIssuerId } from '../issuers/OpenId4VcIssuersControllerTypes'
 

--- a/packages/rest/src/controllers/openid4vc/issuers/OpenId4VcIssuersController.ts
+++ b/packages/rest/src/controllers/openid4vc/issuers/OpenId4VcIssuersController.ts
@@ -2,7 +2,7 @@ import { OpenId4VcIssuerRepository } from '@credo-ts/openid4vc/build/openid4vc-i
 import { Controller, Route, Tags, Security, Post, Request, Body, Delete, Path, Put, Example, Query, Get } from 'tsoa'
 import { injectable } from 'tsyringe'
 
-import { RequestWithAgent } from '../../../authentication'
+import { RequestWithAgent } from '../../../tenantMiddleware'
 import { apiErrorResponse } from '../../../utils/response'
 
 import { openId4VcIssuerRecordExample } from './OpenId4VcIssuersControllerExamples'

--- a/packages/rest/src/controllers/openid4vc/verification-sessions/OpenId4VcVerificationSessionsController.ts
+++ b/packages/rest/src/controllers/openid4vc/verification-sessions/OpenId4VcVerificationSessionsController.ts
@@ -11,7 +11,7 @@ import { OpenId4VcVerificationSessionRepository } from '@credo-ts/openid4vc/buil
 import { Body, Controller, Delete, Example, Get, Path, Post, Query, Request, Route, Security, Tags } from 'tsoa'
 import { injectable } from 'tsyringe'
 
-import { RequestWithAgent } from '../../../authentication'
+import { RequestWithAgent } from '../../../tenantMiddleware'
 import { apiErrorResponse } from '../../../utils/response'
 import { PublicIssuerId } from '../issuers/OpenId4VcIssuersControllerTypes'
 

--- a/packages/rest/src/controllers/openid4vc/verifiers/OpenId4VcVerifiersController.ts
+++ b/packages/rest/src/controllers/openid4vc/verifiers/OpenId4VcVerifiersController.ts
@@ -2,7 +2,7 @@ import { OpenId4VcVerifierRepository } from '@credo-ts/openid4vc/build/openid4vc
 import { Controller, Route, Tags, Security, Post, Request, Body, Delete, Path, Example, Get, Query } from 'tsoa'
 import { injectable } from 'tsyringe'
 
-import { RequestWithAgent } from '../../../authentication'
+import { RequestWithAgent } from '../../../tenantMiddleware'
 import { apiErrorResponse } from '../../../utils/response'
 
 import { openId4VcIssuerRecordExample } from './OpenId4VcVerifiersControllerExamples'

--- a/packages/rest/src/controllers/tenants/TenantControllerExamples.ts
+++ b/packages/rest/src/controllers/tenants/TenantControllerExamples.ts
@@ -1,0 +1,12 @@
+import type { TenantRecord } from './TenantsControllerTypes'
+
+export const tenantRecordExample: TenantRecord = {
+  config: {
+    label: 'Example',
+  },
+  createdAt: new Date('2022-08-18T08:38:40.216Z'),
+  updatedAt: new Date('2022-08-18T08:38:40.216Z'),
+  id: '27137142-2e5b-471b-a427-7d5d3fd6d39b',
+  storageVersion: '0.5',
+  type: 'TenantRecord',
+}

--- a/packages/rest/src/controllers/tenants/TenantsController.ts
+++ b/packages/rest/src/controllers/tenants/TenantsController.ts
@@ -1,11 +1,12 @@
-import type { TenantsRecord } from './TenantsControllerTypes'
+import type { TenantRecord } from './TenantsControllerTypes'
 import type { VersionString } from '@credo-ts/core'
 
-import { Body, Controller, Delete, Get, Path, Post, Put, Query, Request, Route, Security, Tags } from 'tsoa'
+import { Body, Controller, Delete, Example, Get, Path, Post, Put, Query, Request, Route, Security, Tags } from 'tsoa'
 import { injectable } from 'tsyringe'
 
-import { RequestWithRootTenantAgent } from '../../authentication'
+import { RequestWithRootTenantAgent } from '../../tenantMiddleware'
 
+import { tenantRecordExample } from './TenantControllerExamples'
 import { tenantRecordToApiModel, TenantsCreateOptions, TenantsUpdateOptions } from './TenantsControllerTypes'
 
 @Tags('Tenants')
@@ -17,10 +18,11 @@ export class TenantsController extends Controller {
    * create new tenant
    */
   @Post('/')
+  @Example<TenantRecord>(tenantRecordExample)
   public async createTenant(
     @Request() request: RequestWithRootTenantAgent,
     @Body() body: TenantsCreateOptions,
-  ): Promise<TenantsRecord> {
+  ): Promise<TenantRecord> {
     const tenant = await request.user.agent.modules.tenants.createTenant({
       config: body.config,
     })
@@ -32,10 +34,11 @@ export class TenantsController extends Controller {
    * get tenant by id
    */
   @Get('/{tenantId}')
+  @Example<TenantRecord>(tenantRecordExample)
   public async getTenant(
     @Request() request: RequestWithRootTenantAgent,
     @Path('tenantId') tenantId: string,
-  ): Promise<TenantsRecord> {
+  ): Promise<TenantRecord> {
     const tenant = await request.user.agent.modules.tenants.getTenantById(tenantId)
 
     return tenantRecordToApiModel(tenant)
@@ -48,11 +51,12 @@ export class TenantsController extends Controller {
    * If you want to unset an non-required value, you can pass `null`.
    */
   @Put('/{tenantId}')
+  @Example<TenantRecord>(tenantRecordExample)
   public async updateTenant(
     @Request() request: RequestWithRootTenantAgent,
     @Path('tenantId') tenantId: string,
     @Body() body: TenantsUpdateOptions,
-  ): Promise<TenantsRecord> {
+  ): Promise<TenantRecord> {
     const tenantRecord = await request.user.agent.modules.tenants.getTenantById(tenantId)
 
     tenantRecord.config = {
@@ -88,11 +92,12 @@ export class TenantsController extends Controller {
    * get tenants by query
    */
   @Get('/')
+  @Example<TenantRecord[]>([tenantRecordExample])
   public async getTenantsByQuery(
     @Request() request: RequestWithRootTenantAgent,
     @Query('label') label?: string,
     @Query('storageVersion') storageVersion?: string,
-  ): Promise<TenantsRecord[]> {
+  ): Promise<TenantRecord[]> {
     const tenants = await request.user.agent.modules.tenants.findTenantsByQuery({
       label,
       storageVersion: storageVersion as VersionString,

--- a/packages/rest/src/controllers/tenants/TenantsControllerTypes.ts
+++ b/packages/rest/src/controllers/tenants/TenantsControllerTypes.ts
@@ -4,12 +4,12 @@ import type { TenantConfig } from '@credo-ts/tenants/build/models/TenantConfig'
 
 type TenantApiConfig = Omit<TenantConfig, 'walletConfig'>
 
-export interface TenantsRecord extends CredoBaseRecord {
+export interface TenantRecord extends CredoBaseRecord {
   storageVersion: string
   config: TenantApiConfig
 }
 
-export function tenantRecordToApiModel(record: CredoTenantRecord): TenantsRecord {
+export function tenantRecordToApiModel(record: CredoTenantRecord): TenantRecord {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { walletConfig: _, ...config } = record.config
 

--- a/packages/rest/src/generated/routes.ts
+++ b/packages/rest/src/generated/routes.ts
@@ -28,7 +28,7 @@ import { DidController } from './../controllers/did/DidsController';
 import { AnonCredsController } from './../controllers/anoncreds/AnonCredsController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { AgentController } from './../controllers/agent/AgentController';
-import { expressAuthentication } from './../authentication';
+import { expressAuthentication } from './../tenantMiddleware';
 // @ts-ignore - no great way to install types from subpackage
 import { iocContainer } from './../utils/tsyringeTsoaIocContainer';
 import type { IocContainer, IocContainerFactory } from '@tsoa/runtime';
@@ -60,7 +60,7 @@ const models: TsoaRoute.Models = {
         "type": {"dataType":"string","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "TenantsRecord": {
+    "TenantRecord": {
         "dataType": "refObject",
         "properties": {
             "id": {"ref":"RecordId","required":true},

--- a/packages/rest/src/generated/swagger.json
+++ b/packages/rest/src/generated/swagger.json
@@ -1,12128 +1,11942 @@
 {
-	"openapi": "3.0.0",
-	"components": {
-		"examples": {},
-		"headers": {},
-		"parameters": {},
-		"requestBodies": {},
-		"responses": {},
-		"schemas": {
-			"Pick_TenantConfig.Exclude_keyofTenantConfig.walletConfig__": {
-				"properties": {
-					"label": {
-						"type": "string"
-					},
-					"connectionImageUrl": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"label"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"Omit_TenantConfig.walletConfig_": {
-				"$ref": "#/components/schemas/Pick_TenantConfig.Exclude_keyofTenantConfig.walletConfig__",
-				"description": "Construct a type with the properties of T except for those in type K."
-			},
-			"TenantApiConfig": {
-				"$ref": "#/components/schemas/Omit_TenantConfig.walletConfig_"
-			},
-			"RecordId": {
-				"type": "string",
-				"example": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e"
-			},
-			"TenantsRecord": {
-				"properties": {
-					"id": {
-						"$ref": "#/components/schemas/RecordId"
-					},
-					"createdAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"updatedAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"type": {
-						"type": "string"
-					},
-					"storageVersion": {
-						"type": "string"
-					},
-					"config": {
-						"$ref": "#/components/schemas/TenantApiConfig"
-					}
-				},
-				"required": [
-					"id",
-					"createdAt",
-					"type",
-					"storageVersion",
-					"config"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"TenantsCreateOptions": {
-				"properties": {
-					"config": {
-						"properties": {
-							"connectionImageUrl": {
-								"type": "string"
-							},
-							"label": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"label"
-						],
-						"type": "object"
-					}
-				},
-				"required": [
-					"config"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"TenantsUpdateOptions": {
-				"properties": {
-					"config": {
-						"properties": {
-							"connectionImageUrl": {
-								"type": "string",
-								"nullable": true
-							},
-							"label": {
-								"type": "string"
-							}
-						},
-						"type": "object"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"PublicVerifierId": {
-				"type": "string",
-				"description": "The public verifier id, used for hosting SIOP / OAuth2 endpoints and metadata"
-			},
-			"OpenId4VcVerifierRecord": {
-				"properties": {
-					"id": {
-						"$ref": "#/components/schemas/RecordId"
-					},
-					"createdAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"updatedAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"type": {
-						"type": "string"
-					},
-					"publicVerifierId": {
-						"$ref": "#/components/schemas/PublicVerifierId"
-					}
-				},
-				"required": [
-					"id",
-					"createdAt",
-					"type",
-					"publicVerifierId"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"OpenId4VcVerifiersCreateOptions": {
-				"properties": {
-					"publicVerifierId": {
-						"$ref": "#/components/schemas/PublicVerifierId"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false,
-				"example": {}
-			},
-			"OpenId4VcVerificationSessionState": {
-				"enum": [
-					"RequestCreated",
-					"RequestUriRetrieved",
-					"ResponseVerified",
-					"Error"
-				],
-				"type": "string"
-			},
-			"ICredentialContext": {
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"did": {
-						"type": "string"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Record_string.any_": {
-				"properties": {},
-				"additionalProperties": {},
-				"type": "object",
-				"description": "Construct a type with a set of properties K of type T"
-			},
-			"AdditionalClaims": {
-				"$ref": "#/components/schemas/Record_string.any_"
-			},
-			"ICredentialContextType": {
-				"anyOf": [
-					{
-						"allOf": [
-							{
-								"$ref": "#/components/schemas/ICredentialContext"
-							},
-							{
-								"$ref": "#/components/schemas/AdditionalClaims"
-							}
-						]
-					},
-					{
-						"type": "string"
-					}
-				]
-			},
-			"ICredentialSchema": {
-				"properties": {
-					"id": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"id"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"ICredentialSchemaType": {
-				"anyOf": [
-					{
-						"$ref": "#/components/schemas/ICredentialSchema"
-					},
-					{
-						"type": "string"
-					}
-				]
-			},
-			"IIssuerId": {
-				"type": "string"
-			},
-			"IIssuer": {
-				"properties": {
-					"id": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"id"
-				],
-				"type": "object",
-				"additionalProperties": {}
-			},
-			"ICredentialSubject": {
-				"properties": {
-					"id": {
-						"type": "string"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"ICredentialStatus": {
-				"properties": {
-					"id": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"id",
-					"type"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"ICredential": {
-				"properties": {
-					"@context": {
-						"anyOf": [
-							{
-								"$ref": "#/components/schemas/ICredentialContextType"
-							},
-							{
-								"items": {
-									"$ref": "#/components/schemas/ICredentialContextType"
-								},
-								"type": "array"
-							}
-						]
-					},
-					"type": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"credentialSchema": {
-						"anyOf": [
-							{
-								"$ref": "#/components/schemas/ICredentialSchemaType"
-							},
-							{
-								"items": {
-									"$ref": "#/components/schemas/ICredentialSchemaType"
-								},
-								"type": "array"
-							}
-						]
-					},
-					"issuer": {
-						"anyOf": [
-							{
-								"$ref": "#/components/schemas/IIssuerId"
-							},
-							{
-								"$ref": "#/components/schemas/IIssuer"
-							}
-						]
-					},
-					"issuanceDate": {
-						"type": "string"
-					},
-					"credentialSubject": {
-						"anyOf": [
-							{
-								"allOf": [
-									{
-										"$ref": "#/components/schemas/ICredentialSubject"
-									},
-									{
-										"$ref": "#/components/schemas/AdditionalClaims"
-									}
-								]
-							},
-							{
-								"items": {
-									"allOf": [
-										{
-											"$ref": "#/components/schemas/ICredentialSubject"
-										},
-										{
-											"$ref": "#/components/schemas/AdditionalClaims"
-										}
-									]
-								},
-								"type": "array"
-							}
-						]
-					},
-					"expirationDate": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"credentialStatus": {
-						"$ref": "#/components/schemas/ICredentialStatus"
-					},
-					"description": {
-						"type": "string"
-					},
-					"name": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"@context",
-					"type",
-					"issuer",
-					"issuanceDate",
-					"credentialSubject"
-				],
-				"type": "object",
-				"additionalProperties": {}
-			},
-			"IProofType": {
-				"enum": [
-					"Ed25519Signature2018",
-					"Ed25519Signature2020",
-					"EcdsaSecp256k1Signature2019",
-					"EcdsaSecp256k1RecoverySignature2020",
-					"JsonWebSignature2020",
-					"RsaSignature2018",
-					"GpgSignature2020",
-					"JcsEd25519Signature2020",
-					"BbsBlsSignatureProof2020",
-					"BbsBlsBoundSignatureProof2020",
-					"JwtProof2020"
-				],
-				"type": "string"
-			},
-			"IProofPurpose": {
-				"enum": [
-					"verificationMethod",
-					"assertionMethod",
-					"authentication",
-					"keyAgreement",
-					"contactAgreement",
-					"capabilityInvocation",
-					"capabilityDelegation"
-				],
-				"type": "string"
-			},
-			"IProof": {
-				"properties": {
-					"type": {
-						"anyOf": [
-							{
-								"$ref": "#/components/schemas/IProofType"
-							},
-							{
-								"type": "string"
-							}
-						]
-					},
-					"created": {
-						"type": "string"
-					},
-					"proofPurpose": {
-						"anyOf": [
-							{
-								"$ref": "#/components/schemas/IProofPurpose"
-							},
-							{
-								"type": "string"
-							}
-						]
-					},
-					"verificationMethod": {
-						"type": "string"
-					},
-					"challenge": {
-						"type": "string"
-					},
-					"domain": {
-						"type": "string"
-					},
-					"proofValue": {
-						"type": "string"
-					},
-					"jws": {
-						"type": "string"
-					},
-					"jwt": {
-						"type": "string"
-					},
-					"nonce": {
-						"type": "string"
-					},
-					"requiredRevealStatements": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"type",
-					"created",
-					"proofPurpose",
-					"verificationMethod"
-				],
-				"type": "object",
-				"additionalProperties": {}
-			},
-			"IHasProof": {
-				"properties": {
-					"proof": {
-						"anyOf": [
-							{
-								"$ref": "#/components/schemas/IProof"
-							},
-							{
-								"items": {
-									"$ref": "#/components/schemas/IProof"
-								},
-								"type": "array"
-							}
-						]
-					}
-				},
-				"required": [
-					"proof"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"IVerifiableCredential": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/ICredential"
-					},
-					{
-						"$ref": "#/components/schemas/IHasProof"
-					}
-				]
-			},
-			"CompactJWT": {
-				"type": "string",
-				"description": "Represents a Json Web Token in compact form."
-			},
-			"W3CVerifiableCredential": {
-				"anyOf": [
-					{
-						"$ref": "#/components/schemas/IVerifiableCredential"
-					},
-					{
-						"$ref": "#/components/schemas/CompactJWT"
-					}
-				],
-				"description": "Represents a signed Verifiable Credential (includes proof), in either JSON, compact JWT or compact SD-JWT VC format.\nSee {@link https://www.w3.org/TR/vc-data-model/#credentials VC data model}\nSee {@link https://www.w3.org/TR/vc-data-model/#proof-formats proof formats}"
-			},
-			"Descriptor": {
-				"description": "descriptor map laying out the structure of the presentation submission.",
-				"properties": {
-					"id": {
-						"type": "string",
-						"description": "ID to identify the descriptor from Presentation Definition Input Descriptor it coresponds to."
-					},
-					"path": {
-						"type": "string",
-						"description": "The path where the verifiable credential is located in the presentation submission json"
-					},
-					"path_nested": {
-						"$ref": "#/components/schemas/Descriptor"
-					},
-					"format": {
-						"type": "string",
-						"description": "The Proof or JWT algorith that the proof is in"
-					}
-				},
-				"required": [
-					"id",
-					"path",
-					"format"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"PresentationSubmission": {
-				"description": "It expresses how the inputs are presented as proofs to a Verifier.",
-				"properties": {
-					"id": {
-						"type": "string",
-						"description": "A UUID or some other unique ID to identify this Presentation Submission"
-					},
-					"definition_id": {
-						"type": "string",
-						"description": "A UUID or some other unique ID to identify this Presentation Definition"
-					},
-					"descriptor_map": {
-						"items": {
-							"$ref": "#/components/schemas/Descriptor"
-						},
-						"type": "array",
-						"description": "List of descriptors of how the claims are being mapped to presentation definition"
-					}
-				},
-				"required": [
-					"id",
-					"definition_id",
-					"descriptor_map"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"IPresentation": {
-				"properties": {
-					"id": {
-						"type": "string"
-					},
-					"@context": {
-						"anyOf": [
-							{
-								"$ref": "#/components/schemas/ICredentialContextType"
-							},
-							{
-								"items": {
-									"$ref": "#/components/schemas/ICredentialContextType"
-								},
-								"type": "array"
-							}
-						]
-					},
-					"type": {
-						"anyOf": [
-							{
-								"type": "string"
-							},
-							{
-								"items": {
-									"type": "string"
-								},
-								"type": "array"
-							}
-						]
-					},
-					"verifiableCredential": {
-						"items": {
-							"$ref": "#/components/schemas/W3CVerifiableCredential"
-						},
-						"type": "array"
-					},
-					"presentation_submission": {
-						"$ref": "#/components/schemas/PresentationSubmission"
-					},
-					"holder": {
-						"type": "string"
-					},
-					"verifier": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"@context"
-				],
-				"type": "object",
-				"additionalProperties": {}
-			},
-			"IVerifiablePresentation": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/IPresentation"
-					},
-					{
-						"$ref": "#/components/schemas/IHasProof"
-					}
-				]
-			},
-			"W3CVerifiablePresentation": {
-				"anyOf": [
-					{
-						"$ref": "#/components/schemas/IVerifiablePresentation"
-					},
-					{
-						"$ref": "#/components/schemas/CompactJWT"
-					}
-				],
-				"description": "Represents a signed Verifiable Presentation (includes proof), in either JSON or compact JWT format.\nSee {@link https://www.w3.org/TR/vc-data-model/#presentations VC data model}\nSee {@link https://www.w3.org/TR/vc-data-model/#proof-formats proof formats}"
-			},
-			"CompactSdJwtVc": {
-				"type": "string",
-				"description": "Represents a selective disclosure JWT vc in compact form."
-			},
-			"AuthorizationResponsePayload": {
-				"properties": {
-					"access_token": {
-						"type": "string"
-					},
-					"token_type": {
-						"type": "string"
-					},
-					"refresh_token": {
-						"type": "string"
-					},
-					"expires_in": {
-						"type": "number",
-						"format": "double"
-					},
-					"state": {
-						"type": "string"
-					},
-					"id_token": {
-						"type": "string"
-					},
-					"vp_token": {
-						"anyOf": [
-							{
-								"items": {
-									"anyOf": [
-										{
-											"$ref": "#/components/schemas/W3CVerifiablePresentation"
-										},
-										{
-											"$ref": "#/components/schemas/CompactSdJwtVc"
-										}
-									]
-								},
-								"type": "array"
-							},
-							{
-								"$ref": "#/components/schemas/W3CVerifiablePresentation"
-							},
-							{
-								"$ref": "#/components/schemas/CompactSdJwtVc"
-							}
-						]
-					},
-					"presentation_submission": {
-						"$ref": "#/components/schemas/PresentationSubmission"
-					},
-					"verifiedData": {
-						"anyOf": [
-							{
-								"$ref": "#/components/schemas/IPresentation"
-							},
-							{
-								"$ref": "#/components/schemas/AdditionalClaims"
-							}
-						]
-					}
-				},
-				"type": "object",
-				"additionalProperties": {}
-			},
-			"OpenId4VcSiopAuthorizationResponsePayload": {
-				"$ref": "#/components/schemas/AuthorizationResponsePayload"
-			},
-			"OpenId4VcVerificationSessionRecord": {
-				"properties": {
-					"id": {
-						"$ref": "#/components/schemas/RecordId"
-					},
-					"createdAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"updatedAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"type": {
-						"type": "string"
-					},
-					"publicVerifierId": {
-						"$ref": "#/components/schemas/PublicVerifierId"
-					},
-					"state": {
-						"$ref": "#/components/schemas/OpenId4VcVerificationSessionState",
-						"description": "The state of the verification session."
-					},
-					"errorMessage": {
-						"type": "string",
-						"description": "Optional error message of the error that occurred during the verification session. Will be set when state is {@link OpenId4VcVerificationSessionState.Error}"
-					},
-					"authorizationRequestJwt": {
-						"type": "string",
-						"description": "The signed JWT containing the authorization request"
-					},
-					"authorizationRequestUri": {
-						"type": "string",
-						"description": "URI of the authorization request. This is the url that can be used to\nretrieve the authorization request"
-					},
-					"authorizationResponsePayload": {
-						"$ref": "#/components/schemas/OpenId4VcSiopAuthorizationResponsePayload",
-						"description": "The payload of the received authorization response"
-					}
-				},
-				"required": [
-					"id",
-					"createdAt",
-					"type",
-					"publicVerifierId",
-					"state",
-					"authorizationRequestJwt",
-					"authorizationRequestUri"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"OpenId4VcVerificationSessionsCreateRequestResponse": {
-				"properties": {
-					"verificationSession": {
-						"$ref": "#/components/schemas/OpenId4VcVerificationSessionRecord"
-					},
-					"authorizationRequest": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"verificationSession",
-					"authorizationRequest"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"OpenId4VcJwtIssuerDid": {
-				"properties": {
-					"method": {
-						"type": "string",
-						"enum": [
-							"did"
-						],
-						"nullable": false
-					},
-					"didUrl": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"method",
-					"didUrl"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"OpenId4VcJwtIssuer": {
-				"$ref": "#/components/schemas/OpenId4VcJwtIssuerDid"
-			},
-			"JwtObject": {
-				"properties": {
-					"alg": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"alg"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"LdpObject": {
-				"properties": {
-					"proof_type": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"proof_type"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"DiObject": {
-				"properties": {
-					"proof_type": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"cryptosuite": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"proof_type",
-					"cryptosuite"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"SdJwtObject": {
-				"properties": {
-					"undefined": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Format": {
-				"properties": {
-					"jwt": {
-						"$ref": "#/components/schemas/JwtObject"
-					},
-					"jwt_vc": {
-						"$ref": "#/components/schemas/JwtObject"
-					},
-					"jwt_vc_json": {
-						"$ref": "#/components/schemas/JwtObject"
-					},
-					"jwt_vp": {
-						"$ref": "#/components/schemas/JwtObject"
-					},
-					"jwt_vp_json": {
-						"$ref": "#/components/schemas/JwtObject"
-					},
-					"ldp": {
-						"$ref": "#/components/schemas/LdpObject"
-					},
-					"ldp_vc": {
-						"$ref": "#/components/schemas/LdpObject"
-					},
-					"ldp_vp": {
-						"$ref": "#/components/schemas/LdpObject"
-					},
-					"di": {
-						"$ref": "#/components/schemas/DiObject"
-					},
-					"di_vc": {
-						"$ref": "#/components/schemas/DiObject"
-					},
-					"di_vp": {
-						"$ref": "#/components/schemas/DiObject"
-					},
-					"undefined": {
-						"$ref": "#/components/schemas/SdJwtObject"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Rules": {
-				"type": "string",
-				"enum": [
-					"all",
-					"pick"
-				]
-			},
-			"SubmissionRequirement": {
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"purpose": {
-						"type": "string"
-					},
-					"rule": {
-						"$ref": "#/components/schemas/Rules"
-					},
-					"count": {
-						"type": "number",
-						"format": "double"
-					},
-					"min": {
-						"type": "number",
-						"format": "double"
-					},
-					"max": {
-						"type": "number",
-						"format": "double"
-					},
-					"from": {
-						"type": "string"
-					},
-					"from_nested": {
-						"items": {
-							"$ref": "#/components/schemas/SubmissionRequirement"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"rule"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Issuance": {
-				"properties": {
-					"manifest": {
-						"type": "string"
-					}
-				},
-				"type": "object",
-				"additionalProperties": {}
-			},
-			"Optionality": {
-				"type": "string",
-				"enum": [
-					"required",
-					"preferred"
-				]
-			},
-			"Directives": {
-				"type": "string",
-				"enum": [
-					"required",
-					"allowed",
-					"disallowed"
-				]
-			},
-			"PdStatus": {
-				"properties": {
-					"directive": {
-						"$ref": "#/components/schemas/Directives"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Statuses": {
-				"properties": {
-					"active": {
-						"$ref": "#/components/schemas/PdStatus"
-					},
-					"suspended": {
-						"$ref": "#/components/schemas/PdStatus"
-					},
-					"revoked": {
-						"$ref": "#/components/schemas/PdStatus"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"OneOfNumberString": {
-				"anyOf": [
-					{
-						"type": "number",
-						"format": "double"
-					},
-					{
-						"type": "string"
-					}
-				]
-			},
-			"FilterV2Base": {
-				"properties": {
-					"const": {
-						"$ref": "#/components/schemas/OneOfNumberString"
-					},
-					"enum": {
-						"items": {
-							"$ref": "#/components/schemas/OneOfNumberString"
-						},
-						"type": "array"
-					},
-					"exclusiveMinimum": {
-						"$ref": "#/components/schemas/OneOfNumberString"
-					},
-					"exclusiveMaximum": {
-						"$ref": "#/components/schemas/OneOfNumberString"
-					},
-					"format": {
-						"type": "string"
-					},
-					"formatMaximum": {
-						"type": "string"
-					},
-					"formatMinimum": {
-						"type": "string"
-					},
-					"formatExclusiveMaximum": {
-						"type": "string"
-					},
-					"formatExclusiveMinimum": {
-						"type": "string"
-					},
-					"minLength": {
-						"type": "number",
-						"format": "double"
-					},
-					"maxLength": {
-						"type": "number",
-						"format": "double"
-					},
-					"minimum": {
-						"$ref": "#/components/schemas/OneOfNumberString"
-					},
-					"maximum": {
-						"$ref": "#/components/schemas/OneOfNumberString"
-					},
-					"not": {
-						"additionalProperties": false,
-						"type": "object"
-					},
-					"pattern": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"contains": {
-						"$ref": "#/components/schemas/FilterV2Base"
-					},
-					"items": {
-						"$ref": "#/components/schemas/FilterV2BaseItems"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"FilterV2BaseItems": {
-				"properties": {
-					"const": {
-						"$ref": "#/components/schemas/OneOfNumberString"
-					},
-					"enum": {
-						"items": {
-							"$ref": "#/components/schemas/OneOfNumberString"
-						},
-						"type": "array"
-					},
-					"exclusiveMinimum": {
-						"$ref": "#/components/schemas/OneOfNumberString"
-					},
-					"exclusiveMaximum": {
-						"$ref": "#/components/schemas/OneOfNumberString"
-					},
-					"format": {
-						"type": "string"
-					},
-					"formatMaximum": {
-						"type": "string"
-					},
-					"formatMinimum": {
-						"type": "string"
-					},
-					"formatExclusiveMaximum": {
-						"type": "string"
-					},
-					"formatExclusiveMinimum": {
-						"type": "string"
-					},
-					"minLength": {
-						"type": "number",
-						"format": "double"
-					},
-					"maxLength": {
-						"type": "number",
-						"format": "double"
-					},
-					"minimum": {
-						"$ref": "#/components/schemas/OneOfNumberString"
-					},
-					"maximum": {
-						"$ref": "#/components/schemas/OneOfNumberString"
-					},
-					"not": {
-						"additionalProperties": false,
-						"type": "object"
-					},
-					"pattern": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"contains": {
-						"$ref": "#/components/schemas/FilterV2Base"
-					},
-					"items": {
-						"$ref": "#/components/schemas/FilterV2BaseItems"
-					}
-				},
-				"required": [
-					"type"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"FilterV2": {
-				"properties": {
-					"const": {
-						"$ref": "#/components/schemas/OneOfNumberString"
-					},
-					"enum": {
-						"items": {
-							"$ref": "#/components/schemas/OneOfNumberString"
-						},
-						"type": "array"
-					},
-					"exclusiveMinimum": {
-						"$ref": "#/components/schemas/OneOfNumberString"
-					},
-					"exclusiveMaximum": {
-						"$ref": "#/components/schemas/OneOfNumberString"
-					},
-					"format": {
-						"type": "string"
-					},
-					"formatMaximum": {
-						"type": "string"
-					},
-					"formatMinimum": {
-						"type": "string"
-					},
-					"formatExclusiveMaximum": {
-						"type": "string"
-					},
-					"formatExclusiveMinimum": {
-						"type": "string"
-					},
-					"minLength": {
-						"type": "number",
-						"format": "double"
-					},
-					"maxLength": {
-						"type": "number",
-						"format": "double"
-					},
-					"minimum": {
-						"$ref": "#/components/schemas/OneOfNumberString"
-					},
-					"maximum": {
-						"$ref": "#/components/schemas/OneOfNumberString"
-					},
-					"not": {
-						"additionalProperties": false,
-						"type": "object"
-					},
-					"pattern": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"contains": {
-						"$ref": "#/components/schemas/FilterV2Base"
-					},
-					"items": {
-						"$ref": "#/components/schemas/FilterV2BaseItems"
-					}
-				},
-				"required": [
-					"type"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"FieldV2": {
-				"properties": {
-					"id": {
-						"type": "string"
-					},
-					"path": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"purpose": {
-						"type": "string"
-					},
-					"filter": {
-						"$ref": "#/components/schemas/FilterV2"
-					},
-					"predicate": {
-						"$ref": "#/components/schemas/Optionality"
-					},
-					"name": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"path"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"HolderSubject": {
-				"properties": {
-					"field_id": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"directive": {
-						"$ref": "#/components/schemas/Optionality"
-					}
-				},
-				"required": [
-					"field_id",
-					"directive"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"ConstraintsV2": {
-				"properties": {
-					"limit_disclosure": {
-						"$ref": "#/components/schemas/Optionality"
-					},
-					"statuses": {
-						"$ref": "#/components/schemas/Statuses"
-					},
-					"fields": {
-						"items": {
-							"$ref": "#/components/schemas/FieldV2"
-						},
-						"type": "array"
-					},
-					"subject_is_issuer": {
-						"$ref": "#/components/schemas/Optionality"
-					},
-					"is_holder": {
-						"items": {
-							"$ref": "#/components/schemas/HolderSubject"
-						},
-						"type": "array"
-					},
-					"same_subject": {
-						"items": {
-							"$ref": "#/components/schemas/HolderSubject"
-						},
-						"type": "array"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"InputDescriptorV2": {
-				"properties": {
-					"id": {
-						"type": "string"
-					},
-					"name": {
-						"type": "string"
-					},
-					"purpose": {
-						"type": "string"
-					},
-					"format": {
-						"$ref": "#/components/schemas/Format"
-					},
-					"group": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"issuance": {
-						"items": {
-							"$ref": "#/components/schemas/Issuance"
-						},
-						"type": "array"
-					},
-					"constraints": {
-						"$ref": "#/components/schemas/ConstraintsV2"
-					}
-				},
-				"required": [
-					"id",
-					"constraints"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"PresentationDefinitionV2": {
-				"properties": {
-					"id": {
-						"type": "string"
-					},
-					"name": {
-						"type": "string"
-					},
-					"purpose": {
-						"type": "string"
-					},
-					"format": {
-						"$ref": "#/components/schemas/Format"
-					},
-					"submission_requirements": {
-						"items": {
-							"$ref": "#/components/schemas/SubmissionRequirement"
-						},
-						"type": "array"
-					},
-					"input_descriptors": {
-						"items": {
-							"$ref": "#/components/schemas/InputDescriptorV2"
-						},
-						"type": "array"
-					},
-					"frame": {
-						"additionalProperties": false,
-						"type": "object"
-					}
-				},
-				"required": [
-					"id",
-					"input_descriptors"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"DifPresentationExchangeDefinitionV2": {
-				"$ref": "#/components/schemas/PresentationDefinitionV2"
-			},
-			"OpenId4VcVerificationSessionsCreateRequestOptions": {
-				"properties": {
-					"requestSigner": {
-						"$ref": "#/components/schemas/OpenId4VcJwtIssuer",
-						"description": "Signing information for the request JWT. This will be used to sign the request JWT\nand to set the client_id for registration of client_metadata."
-					},
-					"presentationExchange": {
-						"properties": {
-							"definition": {
-								"$ref": "#/components/schemas/DifPresentationExchangeDefinitionV2"
-							}
-						},
-						"required": [
-							"definition"
-						],
-						"type": "object",
-						"description": "A DIF Presentation Definition (v2) can be provided to request a Verifiable Presentation using OpenID4VP."
-					},
-					"publicVerifierId": {
-						"$ref": "#/components/schemas/PublicVerifierId"
-					}
-				},
-				"required": [
-					"requestSigner",
-					"publicVerifierId"
-				],
-				"type": "object",
-				"additionalProperties": false,
-				"example": {
-					"publicVerifierId": "1ab30c0e-1adb-4f01-90e8-cfd425c0a311",
-					"requestSigner": {
-						"method": "did",
-						"didUrl": "did:key:z6MkgViwfstCL1L9i8tgsdAYEu5A62W5mA9DcmSygVVVLFuU#z6MkgViwfstCL1L9i8tgsdAYEu5A62W5mA9DcmSygVVVLFuU"
-					},
-					"presentationExchange": {
-						"definition": {
-							"id": "73797b0c-dae6-46a7-9700-7850855fee22",
-							"name": "Example Presentation Definition",
-							"input_descriptors": [
-								{
-									"id": "64125742-8b6c-422e-82cd-1beb5123ee8f",
-									"constraints": {
-										"limit_disclosure": "required",
-										"fields": [
-											{
-												"path": [
-													"$.age.over_18"
-												],
-												"filter": {
-													"type": "boolean"
-												}
-											}
-										]
-									},
-									"name": "Requested Sd Jwt Example Credential",
-									"purpose": "To provide an example of requesting a credential"
-								}
-							]
-						}
-					}
-				}
-			},
-			"ResponseIss.SELF_ISSUED_V2": {
-				"enum": [
-					"https://self-issued.me/v2"
-				],
-				"type": "string"
-			},
-			"IDTokenPayload": {
-				"properties": {
-					"iss": {
-						"anyOf": [
-							{
-								"$ref": "#/components/schemas/ResponseIss.SELF_ISSUED_V2"
-							},
-							{
-								"type": "string"
-							}
-						]
-					},
-					"sub": {
-						"type": "string"
-					},
-					"aud": {
-						"type": "string"
-					},
-					"iat": {
-						"type": "number",
-						"format": "double"
-					},
-					"nbf": {
-						"type": "number",
-						"format": "double"
-					},
-					"type": {
-						"type": "string"
-					},
-					"exp": {
-						"type": "number",
-						"format": "double"
-					},
-					"rexp": {
-						"type": "number",
-						"format": "double"
-					},
-					"jti": {
-						"type": "string"
-					},
-					"auth_time": {
-						"type": "number",
-						"format": "double"
-					},
-					"nonce": {
-						"type": "string"
-					},
-					"_vp_token": {
-						"properties": {
-							"presentation_submission": {
-								"$ref": "#/components/schemas/PresentationSubmission"
-							}
-						},
-						"required": [
-							"presentation_submission"
-						],
-						"type": "object"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"OpenId4VcSiopIdTokenPayload": {
-				"$ref": "#/components/schemas/IDTokenPayload"
-			},
-			"Schema": {
-				"properties": {
-					"uri": {
-						"type": "string"
-					},
-					"required": {
-						"type": "boolean"
-					}
-				},
-				"required": [
-					"uri"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"FilterV1": {
-				"properties": {
-					"const": {
-						"$ref": "#/components/schemas/OneOfNumberString"
-					},
-					"enum": {
-						"items": {
-							"$ref": "#/components/schemas/OneOfNumberString"
-						},
-						"type": "array"
-					},
-					"exclusiveMinimum": {
-						"$ref": "#/components/schemas/OneOfNumberString"
-					},
-					"exclusiveMaximum": {
-						"$ref": "#/components/schemas/OneOfNumberString"
-					},
-					"format": {
-						"type": "string"
-					},
-					"minLength": {
-						"type": "number",
-						"format": "double"
-					},
-					"maxLength": {
-						"type": "number",
-						"format": "double"
-					},
-					"minimum": {
-						"$ref": "#/components/schemas/OneOfNumberString"
-					},
-					"maximum": {
-						"$ref": "#/components/schemas/OneOfNumberString"
-					},
-					"not": {
-						"additionalProperties": false,
-						"type": "object"
-					},
-					"pattern": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"type"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"FieldV1": {
-				"properties": {
-					"id": {
-						"type": "string"
-					},
-					"path": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"purpose": {
-						"type": "string"
-					},
-					"filter": {
-						"$ref": "#/components/schemas/FilterV1"
-					},
-					"predicate": {
-						"$ref": "#/components/schemas/Optionality"
-					}
-				},
-				"required": [
-					"path"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"ConstraintsV1": {
-				"properties": {
-					"limit_disclosure": {
-						"$ref": "#/components/schemas/Optionality"
-					},
-					"statuses": {
-						"$ref": "#/components/schemas/Statuses"
-					},
-					"fields": {
-						"items": {
-							"$ref": "#/components/schemas/FieldV1"
-						},
-						"type": "array"
-					},
-					"subject_is_issuer": {
-						"$ref": "#/components/schemas/Optionality"
-					},
-					"is_holder": {
-						"items": {
-							"$ref": "#/components/schemas/HolderSubject"
-						},
-						"type": "array"
-					},
-					"same_subject": {
-						"items": {
-							"$ref": "#/components/schemas/HolderSubject"
-						},
-						"type": "array"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"InputDescriptorV1": {
-				"properties": {
-					"id": {
-						"type": "string"
-					},
-					"name": {
-						"type": "string"
-					},
-					"purpose": {
-						"type": "string"
-					},
-					"group": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"schema": {
-						"items": {
-							"$ref": "#/components/schemas/Schema"
-						},
-						"type": "array"
-					},
-					"issuance": {
-						"items": {
-							"$ref": "#/components/schemas/Issuance"
-						},
-						"type": "array"
-					},
-					"constraints": {
-						"$ref": "#/components/schemas/ConstraintsV1"
-					}
-				},
-				"required": [
-					"id",
-					"schema"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"PresentationDefinitionV1": {
-				"properties": {
-					"id": {
-						"type": "string"
-					},
-					"name": {
-						"type": "string"
-					},
-					"purpose": {
-						"type": "string"
-					},
-					"format": {
-						"$ref": "#/components/schemas/Format"
-					},
-					"submission_requirements": {
-						"items": {
-							"$ref": "#/components/schemas/SubmissionRequirement"
-						},
-						"type": "array"
-					},
-					"input_descriptors": {
-						"items": {
-							"$ref": "#/components/schemas/InputDescriptorV1"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"id",
-					"input_descriptors"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"DifPresentationExchangeDefinition": {
-				"anyOf": [
-					{
-						"$ref": "#/components/schemas/PresentationDefinitionV1"
-					},
-					{
-						"$ref": "#/components/schemas/PresentationDefinitionV2"
-					}
-				]
-			},
-			"ClaimFormat.SdJwtVc": {
-				"enum": [
-					"vc+sd-jwt"
-				],
-				"type": "string"
-			},
-			"JwtPayloadJson": {
-				"properties": {
-					"iss": {
-						"type": "string"
-					},
-					"sub": {
-						"type": "string"
-					},
-					"aud": {
-						"anyOf": [
-							{
-								"type": "string"
-							},
-							{
-								"items": {
-									"type": "string"
-								},
-								"type": "array"
-							}
-						]
-					},
-					"exp": {
-						"type": "number",
-						"format": "double"
-					},
-					"nbf": {
-						"type": "number",
-						"format": "double"
-					},
-					"iat": {
-						"type": "number",
-						"format": "double"
-					},
-					"jti": {
-						"type": "string"
-					}
-				},
-				"type": "object",
-				"additionalProperties": {}
-			},
-			"JwkJson": {
-				"properties": {
-					"kty": {
-						"type": "string"
-					},
-					"use": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"kty"
-				],
-				"type": "object",
-				"additionalProperties": {}
-			},
-			"JwtHeader": {
-				"properties": {
-					"alg": {
-						"type": "string"
-					},
-					"kid": {
-						"type": "string"
-					},
-					"jwk": {
-						"$ref": "#/components/schemas/JwkJson"
-					}
-				},
-				"required": [
-					"alg"
-				],
-				"type": "object",
-				"additionalProperties": {}
-			},
-			"ClaimFormat.JwtVp": {
-				"enum": [
-					"jwt_vp"
-				],
-				"type": "string"
-			},
-			"JsonObject": {
-				"properties": {},
-				"type": "object",
-				"additionalProperties": {
-					"$ref": "#/components/schemas/JsonValue"
-				}
-			},
-			"JsonValue": {
-				"anyOf": [
-					{
-						"type": "string"
-					},
-					{
-						"type": "number",
-						"format": "double"
-					},
-					{
-						"type": "boolean"
-					},
-					{
-						"$ref": "#/components/schemas/JsonObject"
-					},
-					{
-						"$ref": "#/components/schemas/JsonArray"
-					}
-				],
-				"nullable": true
-			},
-			"JsonArray": {
-				"items": {
-					"$ref": "#/components/schemas/JsonValue"
-				},
-				"type": "array"
-			},
-			"SingleOrArray_JsonObject_": {
-				"anyOf": [
-					{
-						"$ref": "#/components/schemas/JsonObject"
-					},
-					{
-						"items": {
-							"$ref": "#/components/schemas/JsonObject"
-						},
-						"type": "array"
-					}
-				]
-			},
-			"W3cJsonCredential": {
-				"properties": {
-					"@context": {
-						"items": {
-							"anyOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/components/schemas/JsonObject"
-								}
-							]
-						},
-						"type": "array"
-					},
-					"id": {
-						"type": "string"
-					},
-					"type": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"issuer": {
-						"anyOf": [
-							{
-								"type": "string"
-							},
-							{
-								"properties": {
-									"id": {
-										"type": "string"
-									}
-								},
-								"type": "object"
-							}
-						]
-					},
-					"issuanceDate": {
-						"type": "string"
-					},
-					"expirationDate": {
-						"type": "string"
-					},
-					"credentialSubject": {
-						"$ref": "#/components/schemas/SingleOrArray_JsonObject_"
-					}
-				},
-				"required": [
-					"@context",
-					"type",
-					"issuer",
-					"issuanceDate",
-					"credentialSubject"
-				],
-				"type": "object",
-				"additionalProperties": {}
-			},
-			"W3cJsonPresentation": {
-				"properties": {
-					"@context": {
-						"items": {
-							"anyOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/components/schemas/JsonObject"
-								}
-							]
-						},
-						"type": "array"
-					},
-					"id": {
-						"type": "string"
-					},
-					"type": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"holder": {
-						"anyOf": [
-							{
-								"type": "string"
-							},
-							{
-								"properties": {
-									"id": {
-										"type": "string"
-									}
-								},
-								"type": "object"
-							}
-						]
-					},
-					"verifiableCredential": {
-						"items": {
-							"anyOf": [
-								{
-									"$ref": "#/components/schemas/W3cJsonCredential"
-								},
-								{
-									"type": "string"
-								}
-							]
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"@context",
-					"type",
-					"holder",
-					"verifiableCredential"
-				],
-				"type": "object",
-				"additionalProperties": {}
-			},
-			"ClaimFormat.LdpVp": {
-				"enum": [
-					"ldp_vp"
-				],
-				"type": "string"
-			},
-			"OpenId4VcVerificationSessionsGetVerifiedAuthorizationResponseResponse": {
-				"description": "Either `idToken` and/or `presentationExchange` will be present, but not none.",
-				"properties": {
-					"idToken": {
-						"properties": {
-							"payload": {
-								"$ref": "#/components/schemas/OpenId4VcSiopIdTokenPayload"
-							}
-						},
-						"required": [
-							"payload"
-						],
-						"type": "object"
-					},
-					"presentationExchange": {
-						"properties": {
-							"presentations": {
-								"items": {
-									"anyOf": [
-										{
-											"properties": {
-												"header": {
-													"$ref": "#/components/schemas/JwtHeader"
-												},
-												"signedPayload": {
-													"$ref": "#/components/schemas/JwtPayloadJson"
-												},
-												"vcPayload": {
-													"$ref": "#/components/schemas/JwtPayloadJson"
-												},
-												"encoded": {
-													"type": "string"
-												},
-												"format": {
-													"$ref": "#/components/schemas/ClaimFormat.SdJwtVc"
-												}
-											},
-											"required": [
-												"header",
-												"signedPayload",
-												"vcPayload",
-												"encoded",
-												"format"
-											],
-											"type": "object"
-										},
-										{
-											"properties": {
-												"header": {
-													"$ref": "#/components/schemas/JwtHeader"
-												},
-												"signedPayload": {
-													"$ref": "#/components/schemas/JwtPayloadJson"
-												},
-												"vcPayload": {
-													"$ref": "#/components/schemas/W3cJsonPresentation"
-												},
-												"encoded": {
-													"type": "string"
-												},
-												"format": {
-													"$ref": "#/components/schemas/ClaimFormat.JwtVp"
-												}
-											},
-											"required": [
-												"header",
-												"signedPayload",
-												"vcPayload",
-												"encoded",
-												"format"
-											],
-											"type": "object"
-										},
-										{
-											"properties": {
-												"vcPayload": {
-													"$ref": "#/components/schemas/W3cJsonPresentation"
-												},
-												"encoded": {
-													"$ref": "#/components/schemas/W3cJsonPresentation"
-												},
-												"format": {
-													"$ref": "#/components/schemas/ClaimFormat.LdpVp"
-												}
-											},
-											"required": [
-												"vcPayload",
-												"encoded",
-												"format"
-											],
-											"type": "object"
-										}
-									]
-								},
-								"type": "array"
-							},
-							"definition": {
-								"$ref": "#/components/schemas/DifPresentationExchangeDefinition"
-							},
-							"submission": {
-								"$ref": "#/components/schemas/PresentationSubmission"
-							}
-						},
-						"required": [
-							"presentations",
-							"definition",
-							"submission"
-						],
-						"type": "object"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"PublicIssuerId": {
-				"type": "string",
-				"description": "The public issuer id, used for hosting OpenID4VCI metadata and endpoints"
-			},
-			"CredentialSupportedBrief": {
-				"properties": {
-					"cryptographic_binding_methods_supported": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"cryptographic_suites_supported": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"OID4VCICredentialFormat": {
-				"type": "string",
-				"enum": [
-					"jwt_vc_json",
-					"jwt_vc_json-ld",
-					"ldp_vc",
-					"vc+sd-jwt",
-					"jwt_vc"
-				]
-			},
-			"NameAndLocale": {
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"locale": {
-						"type": "string"
-					}
-				},
-				"type": "object",
-				"additionalProperties": {}
-			},
-			"ImageInfo": {
-				"description": "Important Note: please be aware that these Common interfaces are based on versions v1_0.11 and v1_0.09",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"alt_text": {
-						"type": "string"
-					}
-				},
-				"type": "object",
-				"additionalProperties": {}
-			},
-			"LogoAndColor": {
-				"properties": {
-					"logo": {
-						"$ref": "#/components/schemas/ImageInfo"
-					},
-					"description": {
-						"type": "string"
-					},
-					"background_color": {
-						"type": "string"
-					},
-					"text_color": {
-						"type": "string"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"CredentialsSupportedDisplay": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/NameAndLocale"
-					},
-					{
-						"$ref": "#/components/schemas/LogoAndColor"
-					},
-					{
-						"properties": {
-							"background_image": {
-								"$ref": "#/components/schemas/ImageInfo"
-							},
-							"name": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"name"
-						],
-						"type": "object"
-					}
-				]
-			},
-			"CommonCredentialSupported": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/CredentialSupportedBrief"
-					},
-					{
-						"properties": {
-							"display": {
-								"items": {
-									"$ref": "#/components/schemas/CredentialsSupportedDisplay"
-								},
-								"type": "array"
-							},
-							"id": {
-								"type": "string"
-							},
-							"format": {
-								"anyOf": [
-									{
-										"$ref": "#/components/schemas/OID4VCICredentialFormat"
-									},
-									{
-										"type": "string"
-									}
-								]
-							}
-						},
-						"required": [
-							"format"
-						],
-						"type": "object"
-					}
-				]
-			},
-			"CredentialSubjectDisplay": {
-				"properties": {
-					"mandatory": {
-						"type": "boolean"
-					},
-					"value_type": {
-						"type": "string"
-					},
-					"display": {
-						"items": {
-							"$ref": "#/components/schemas/NameAndLocale"
-						},
-						"type": "array"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"IssuerCredentialSubjectDisplay": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/CredentialSubjectDisplay"
-					},
-					{
-						"properties": {},
-						"additionalProperties": {
-							"$ref": "#/components/schemas/CredentialSubjectDisplay"
-						},
-						"type": "object"
-					}
-				]
-			},
-			"IssuerCredentialSubject": {
-				"properties": {},
-				"type": "object",
-				"additionalProperties": {
-					"$ref": "#/components/schemas/IssuerCredentialSubjectDisplay"
-				}
-			},
-			"CredentialSupportedJwtVcJson": {
-				"properties": {
-					"types": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"credentialSubject": {
-						"$ref": "#/components/schemas/IssuerCredentialSubject"
-					},
-					"order": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"format": {
-						"type": "string",
-						"enum": [
-							"jwt_vc_json",
-							"jwt_vc"
-						]
-					}
-				},
-				"required": [
-					"types",
-					"format"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"CredentialSupportedJwtVcJsonLdAndLdpVc": {
-				"properties": {
-					"types": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"@context": {
-						"items": {
-							"$ref": "#/components/schemas/ICredentialContextType"
-						},
-						"type": "array"
-					},
-					"credentialSubject": {
-						"$ref": "#/components/schemas/IssuerCredentialSubject"
-					},
-					"order": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"format": {
-						"type": "string",
-						"enum": [
-							"ldp_vc",
-							"jwt_vc_json-ld"
-						]
-					}
-				},
-				"required": [
-					"types",
-					"@context",
-					"format"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"CredentialSupportedSdJwtVc": {
-				"properties": {
-					"format": {
-						"type": "string",
-						"enum": [
-							"vc+sd-jwt"
-						],
-						"nullable": false
-					},
-					"vct": {
-						"type": "string"
-					},
-					"claims": {
-						"$ref": "#/components/schemas/IssuerCredentialSubject"
-					},
-					"order": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"format",
-					"vct"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"CredentialSupported": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/CommonCredentialSupported"
-					},
-					{
-						"anyOf": [
-							{
-								"$ref": "#/components/schemas/CredentialSupportedJwtVcJson"
-							},
-							{
-								"$ref": "#/components/schemas/CredentialSupportedJwtVcJsonLdAndLdpVc"
-							},
-							{
-								"$ref": "#/components/schemas/CredentialSupportedSdJwtVc"
-							}
-						]
-					}
-				]
-			},
-			"OpenId4VciCredentialSupportedWithId": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/CredentialSupported"
-					},
-					{
-						"properties": {
-							"id": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"id"
-						],
-						"type": "object"
-					}
-				]
-			},
-			"MetadataDisplay": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/NameAndLocale"
-					},
-					{
-						"$ref": "#/components/schemas/LogoAndColor"
-					},
-					{
-						"properties": {
-							"name": {
-								"type": "string"
-							}
-						},
-						"type": "object"
-					}
-				]
-			},
-			"OpenId4VciIssuerMetadataDisplay": {
-				"$ref": "#/components/schemas/MetadataDisplay"
-			},
-			"OpenId4VcIssuerRecord": {
-				"properties": {
-					"id": {
-						"$ref": "#/components/schemas/RecordId"
-					},
-					"createdAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"updatedAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"type": {
-						"type": "string"
-					},
-					"publicIssuerId": {
-						"$ref": "#/components/schemas/PublicIssuerId"
-					},
-					"accessTokenPublicKeyFingerprint": {
-						"type": "string"
-					},
-					"credentialsSupported": {
-						"items": {
-							"$ref": "#/components/schemas/OpenId4VciCredentialSupportedWithId"
-						},
-						"type": "array"
-					},
-					"display": {
-						"items": {
-							"$ref": "#/components/schemas/OpenId4VciIssuerMetadataDisplay"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"id",
-					"createdAt",
-					"type",
-					"publicIssuerId",
-					"accessTokenPublicKeyFingerprint",
-					"credentialsSupported"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"OpenId4VcIssuersCreateOptions": {
-				"properties": {
-					"publicIssuerId": {
-						"$ref": "#/components/schemas/PublicIssuerId"
-					},
-					"credentialsSupported": {
-						"items": {
-							"$ref": "#/components/schemas/OpenId4VciCredentialSupportedWithId"
-						},
-						"type": "array"
-					},
-					"display": {
-						"items": {
-							"$ref": "#/components/schemas/OpenId4VciIssuerMetadataDisplay"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"credentialsSupported"
-				],
-				"type": "object",
-				"additionalProperties": false,
-				"example": {
-					"credentialsSupported": [
-						{
-							"format": "vc+sd-jwt",
-							"id": "ExampleCredentialSdJwtVc",
-							"vct": "https://example.com/vct#ExampleCredential",
-							"cryptographic_binding_methods_supported": [
-								"did:key",
-								"did:jwk"
-							],
-							"cryptographic_suites_supported": [
-								"ES256",
-								"Ed25519"
-							],
-							"display": [
-								{
-									"name": "Example SD JWT Credential",
-									"description": "This is an example SD-JWT credential",
-									"background_color": "#ffffff",
-									"background_image": {
-										"url": "https://example.com/background.png",
-										"alt_text": "Example Credential Background"
-									},
-									"text_color": "#000000",
-									"locale": "en-US",
-									"logo": {
-										"url": "https://example.com/logo.png",
-										"alt_text": "Example Credential Logo"
-									}
-								}
-							]
-						},
-						{
-							"format": "jwt_vc_json",
-							"id": "ExampleCredentialJwtVc",
-							"types": [
-								"VerifiableCredential",
-								"ExampleCredential"
-							],
-							"cryptographic_binding_methods_supported": [
-								"did:key",
-								"did:jwk"
-							],
-							"cryptographic_suites_supported": [
-								"ES256",
-								"Ed25519"
-							],
-							"display": [
-								{
-									"name": "Example SD JWT Credential",
-									"description": "This is an example SD-JWT credential",
-									"background_color": "#ffffff",
-									"background_image": {
-										"url": "https://example.com/background.png",
-										"alt_text": "Example Credential Background"
-									},
-									"text_color": "#000000",
-									"locale": "en-US",
-									"logo": {
-										"url": "https://example.com/logo.png",
-										"alt_text": "Example Credential Logo"
-									}
-								}
-							]
-						}
-					],
-					"display": [
-						{
-							"background_color": "#ffffff",
-							"description": "This is an example issuer",
-							"name": "Example Issuer",
-							"locale": "en-US",
-							"logo": {
-								"alt_text": "Example Issuer Logo",
-								"url": "https://example.com/logo.png"
-							},
-							"text_color": "#000000"
-						}
-					]
-				}
-			},
-			"OpenId4VcIssuersUpdateMetadataOptions": {
-				"properties": {
-					"credentialsSupported": {
-						"items": {
-							"$ref": "#/components/schemas/OpenId4VciCredentialSupportedWithId"
-						},
-						"type": "array"
-					},
-					"display": {
-						"items": {
-							"$ref": "#/components/schemas/OpenId4VciIssuerMetadataDisplay"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"credentialsSupported"
-				],
-				"type": "object",
-				"additionalProperties": false,
-				"example": {
-					"credentialsSupported": [
-						{
-							"format": "vc+sd-jwt",
-							"id": "ExampleCredentialSdJwtVc",
-							"vct": "https://example.com/vct#ExampleCredential",
-							"cryptographic_binding_methods_supported": [
-								"did:key",
-								"did:jwk"
-							],
-							"cryptographic_suites_supported": [
-								"ES256",
-								"Ed25519"
-							],
-							"display": [
-								{
-									"name": "Example SD JWT Credential",
-									"description": "This is an example SD-JWT credential",
-									"background_color": "#ffffff",
-									"background_image": {
-										"url": "https://example.com/background.png",
-										"alt_text": "Example Credential Background"
-									},
-									"text_color": "#000000",
-									"locale": "en-US",
-									"logo": {
-										"url": "https://example.com/logo.png",
-										"alt_text": "Example Credential Logo"
-									}
-								}
-							]
-						},
-						{
-							"format": "jwt_vc_json",
-							"id": "ExampleCredentialJwtVc",
-							"types": [
-								"VerifiableCredential",
-								"ExampleCredential"
-							],
-							"cryptographic_binding_methods_supported": [
-								"did:key",
-								"did:jwk"
-							],
-							"cryptographic_suites_supported": [
-								"ES256",
-								"Ed25519"
-							],
-							"display": [
-								{
-									"name": "Example SD JWT Credential",
-									"description": "This is an example SD-JWT credential",
-									"background_color": "#ffffff",
-									"background_image": {
-										"url": "https://example.com/background.png",
-										"alt_text": "Example Credential Background"
-									},
-									"text_color": "#000000",
-									"locale": "en-US",
-									"logo": {
-										"url": "https://example.com/logo.png",
-										"alt_text": "Example Credential Logo"
-									}
-								}
-							]
-						}
-					],
-					"display": [
-						{
-							"background_color": "#ffffff",
-							"description": "This is an example issuer",
-							"name": "Example Issuer",
-							"locale": "en-US",
-							"logo": {
-								"alt_text": "Example Issuer Logo",
-								"url": "https://example.com/logo.png"
-							},
-							"text_color": "#000000"
-						}
-					]
-				}
-			},
-			"OpenId4VcIssuanceSessionState": {
-				"enum": [
-					"OfferCreated",
-					"OfferUriRetrieved",
-					"AccessTokenRequested",
-					"AccessTokenCreated",
-					"CredentialRequestReceived",
-					"CredentialIssued",
-					"Error"
-				],
-				"type": "string"
-			},
-			"Record_string.unknown_": {
-				"properties": {},
-				"additionalProperties": {},
-				"type": "object",
-				"description": "Construct a type with a set of properties K of type T"
-			},
-			"CommonCredentialOfferFormat": {
-				"properties": {
-					"format": {
-						"anyOf": [
-							{
-								"$ref": "#/components/schemas/OID4VCICredentialFormat"
-							},
-							{
-								"type": "string"
-							}
-						]
-					}
-				},
-				"required": [
-					"format"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"JsonLdIssuerCredentialDefinition": {
-				"properties": {
-					"@context": {
-						"items": {
-							"$ref": "#/components/schemas/ICredentialContextType"
-						},
-						"type": "array"
-					},
-					"types": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"credentialSubject": {
-						"$ref": "#/components/schemas/IssuerCredentialSubject"
-					}
-				},
-				"required": [
-					"@context",
-					"types"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"CredentialOfferFormatJwtVcJsonLdAndLdpVc": {
-				"properties": {
-					"format": {
-						"type": "string",
-						"enum": [
-							"ldp_vc",
-							"jwt_vc_json-ld"
-						]
-					},
-					"credential_definition": {
-						"$ref": "#/components/schemas/JsonLdIssuerCredentialDefinition"
-					}
-				},
-				"required": [
-					"format",
-					"credential_definition"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"CredentialOfferFormatJwtVcJson": {
-				"properties": {
-					"format": {
-						"type": "string",
-						"enum": [
-							"jwt_vc_json",
-							"jwt_vc"
-						]
-					},
-					"types": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"format",
-					"types"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"CredentialOfferFormatSdJwtVc": {
-				"properties": {
-					"format": {
-						"type": "string",
-						"enum": [
-							"vc+sd-jwt"
-						],
-						"nullable": false
-					},
-					"vct": {
-						"type": "string"
-					},
-					"claims": {
-						"$ref": "#/components/schemas/IssuerCredentialSubject"
-					}
-				},
-				"required": [
-					"format",
-					"vct"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"CredentialOfferFormat": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/CommonCredentialOfferFormat"
-					},
-					{
-						"anyOf": [
-							{
-								"$ref": "#/components/schemas/CredentialOfferFormatJwtVcJsonLdAndLdpVc"
-							},
-							{
-								"$ref": "#/components/schemas/CredentialOfferFormatJwtVcJson"
-							},
-							{
-								"$ref": "#/components/schemas/CredentialOfferFormatSdJwtVc"
-							}
-						]
-					}
-				]
-			},
-			"GrantAuthorizationCode": {
-				"properties": {
-					"issuer_state": {
-						"type": "string",
-						"description": "OPTIONAL. String value created by the Credential Issuer and opaque to the Wallet that is used to bind the subsequent\nAuthorization Request with the Credential Issuer to a context set up during previous steps."
-					},
-					"authorization_server": {
-						"type": "string",
-						"description": "OPTIONAL string that the Wallet can use to identify the Authorization Server to use with this grant type when authorization_servers parameter in the Credential Issuer metadata has multiple entries. MUST NOT be used otherwise. The value of this parameter MUST match with one of the values in the authorization_servers array obtained from the Credential Issuer metadata"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"GrantUrnIetf": {
-				"properties": {
-					"pre-authorized_code": {
-						"type": "string",
-						"description": "REQUIRED. The code representing the Credential Issuer's authorization for the Wallet to obtain Credentials of a certain type."
-					},
-					"user_pin_required": {
-						"type": "boolean",
-						"description": "OPTIONAL. Boolean value specifying whether the Credential Issuer expects presentation of a user PIN along with the Token Request\nin a Pre-Authorized Code Flow. Default is false."
-					},
-					"interval": {
-						"type": "number",
-						"format": "double",
-						"description": "OPTIONAL. The minimum amount of time in seconds that the Wallet SHOULD wait between polling requests to the token endpoint (in case the Authorization Server responds with error code authorization_pending - see Section 6.3). If no value is provided, Wallets MUST use 5 as the default."
-					},
-					"authorization_server": {
-						"type": "string",
-						"description": "OPTIONAL string that the Wallet can use to identify the Authorization Server to use with this grant type when authorization_servers parameter in the Credential Issuer metadata has multiple entries. MUST NOT be used otherwise. The value of this parameter MUST match with one of the values in the authorization_servers array obtained from the Credential Issuer metadata"
-					}
-				},
-				"required": [
-					"pre-authorized_code",
-					"user_pin_required"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Grant": {
-				"properties": {
-					"authorization_code": {
-						"$ref": "#/components/schemas/GrantAuthorizationCode"
-					},
-					"urn:ietf:params:oauth:grant-type:pre-authorized_code": {
-						"$ref": "#/components/schemas/GrantUrnIetf"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"CredentialOfferPayloadV1_0_11": {
-				"properties": {
-					"credential_issuer": {
-						"type": "string",
-						"description": "REQUIRED. The URL of the Credential Issuer, the Wallet is requested to obtain one or more Credentials from."
-					},
-					"credentials": {
-						"items": {
-							"anyOf": [
-								{
-									"$ref": "#/components/schemas/CredentialOfferFormat"
-								},
-								{
-									"type": "string"
-								}
-							]
-						},
-						"type": "array",
-						"description": "REQUIRED. A JSON array, where every entry is a JSON object or a JSON string. If the entry is an object,\nthe object contains the data related to a certain credential type the Wallet MAY request.\nEach object MUST contain a format Claim determining the format of the credential to be requested and\nfurther parameters characterising the type of the credential to be requested as defined in Appendix E.\nIf the entry is a string, the string value MUST be one of the id values in one of the objects in the\ncredentials_supported Credential Issuer metadata parameter.\nWhen processing, the Wallet MUST resolve this string value to the respective object."
-					},
-					"grants": {
-						"$ref": "#/components/schemas/Grant",
-						"description": "OPTIONAL. A JSON object indicating to the Wallet the Grant Types the Credential Issuer's AS is prepared\nto process for this credential offer. Every grant is represented by a key and an object.\nThe key value is the Grant Type identifier, the object MAY contain parameters either determining the way\nthe Wallet MUST use the particular grant and/or parameters the Wallet MUST send with the respective request(s).\nIf grants is not present or empty, the Wallet MUST determine the Grant Types the Credential Issuer's AS supports\nusing the respective metadata. When multiple grants are present, it's at the Wallet's discretion which one to use."
-					},
-					"client_id": {
-						"type": "string",
-						"description": "Some implementations might include a client_id in the offer. For instance EBSI in a same-device flow. (Cross-device tucks it in the state JWT)"
-					}
-				},
-				"required": [
-					"credential_issuer",
-					"credentials"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"OpenId4VciCredentialOfferPayload": {
-				"$ref": "#/components/schemas/CredentialOfferPayloadV1_0_11"
-			},
-			"OpenId4VcIssuanceSessionRecord": {
-				"properties": {
-					"id": {
-						"$ref": "#/components/schemas/RecordId"
-					},
-					"createdAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"updatedAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"type": {
-						"type": "string"
-					},
-					"publicIssuerId": {
-						"$ref": "#/components/schemas/PublicIssuerId"
-					},
-					"state": {
-						"$ref": "#/components/schemas/OpenId4VcIssuanceSessionState",
-						"description": "The state of the issuance session."
-					},
-					"cNonce": {
-						"type": "string",
-						"description": "cNonce that should be used in the credential request by the holder."
-					},
-					"cNonceExpiresAt": {
-						"type": "string",
-						"format": "date-time",
-						"description": "The time at which the cNonce expires."
-					},
-					"preAuthorizedCode": {
-						"type": "string",
-						"description": "Pre authorized code used for the issuance session. Only used when a pre-authorized credential\noffer is created."
-					},
-					"userPin": {
-						"type": "string",
-						"description": "Optional user pin that needs to be provided by the user in the access token request."
-					},
-					"issuanceMetadata": {
-						"$ref": "#/components/schemas/Record_string.unknown_",
-						"description": "User-defined metadata that will be provided to the credential request to credential mapper\nto allow to retrieve the needed credential input data. Can be the credential data itself,\nor some other data that is needed to retrieve the credential data."
-					},
-					"credentialOfferPayload": {
-						"$ref": "#/components/schemas/OpenId4VciCredentialOfferPayload",
-						"description": "The credential offer that was used to create the issuance session."
-					},
-					"credentialOfferUri": {
-						"type": "string",
-						"description": "URI of the credential offer. This is the url that cn can be used to retrieve\nthe credential offer"
-					},
-					"errorMessage": {
-						"type": "string",
-						"description": "Optional error message of the error that occurred during the issuance session. Will be set when state is {@link OpenId4VcIssuanceSessionState.Error}"
-					}
-				},
-				"required": [
-					"id",
-					"createdAt",
-					"type",
-					"publicIssuerId",
-					"state",
-					"credentialOfferPayload",
-					"credentialOfferUri"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"OpenId4VcIssuanceSessionsCreateOfferResponse": {
-				"properties": {
-					"issuanceSession": {
-						"$ref": "#/components/schemas/OpenId4VcIssuanceSessionRecord"
-					},
-					"credentialOffer": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"issuanceSession",
-					"credentialOffer"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"OpenId4VciCredentialFormatProfile.SdJwtVc": {
-				"enum": [
-					"vc+sd-jwt"
-				],
-				"type": "string"
-			},
-			"Did": {
-				"type": "string"
-			},
-			"DisclosureFrame": {
-				"properties": {},
-				"additionalProperties": {
-					"anyOf": [
-						{
-							"type": "boolean"
-						},
-						{
-							"$ref": "#/components/schemas/DisclosureFrame"
-						}
-					]
-				},
-				"type": "object"
-			},
-			"OpenId4VcIssuanceSessionCreateOfferSdJwtCredentialOptions": {
-				"properties": {
-					"credentialSupportedId": {
-						"type": "string",
-						"description": "The id of the `credential_supported` entry that is present in the issuer\nmetadata. This id is used to identify the credential that is being offered.",
-						"example": "ExampleCredentialSdJwtVc"
-					},
-					"format": {
-						"$ref": "#/components/schemas/OpenId4VciCredentialFormatProfile.SdJwtVc",
-						"description": "The format of the credential that is being offered.\nMUST match the format of the `credential_supported` entry."
-					},
-					"issuer": {
-						"properties": {
-							"didUrl": {
-								"$ref": "#/components/schemas/Did"
-							},
-							"method": {
-								"type": "string",
-								"enum": [
-									"did"
-								],
-								"nullable": false
-							}
-						},
-						"required": [
-							"didUrl",
-							"method"
-						],
-						"type": "object",
-						"description": "The issuer of the credential.\n\nOnly DID based issuance is supported at the moment."
-					},
-					"payload": {
-						"properties": {
-							"vct": {
-								"type": "string"
-							}
-						},
-						"additionalProperties": {},
-						"type": "object",
-						"description": "The payload of the credential that will be issued.\n\nIf `vct` claim is included, it MUST match the `vct` claim from the issuer metadata.\nIf `vct` claim is not included, it will be added automatically.",
-						"example": {
-							"first_name": "John",
-							"last_name": "Doe",
-							"age": {
-								"over_18": true,
-								"over_21": true,
-								"over_65": false
-							}
-						}
-					},
-					"disclosureFrame": {
-						"$ref": "#/components/schemas/DisclosureFrame",
-						"description": "Disclosure frame indicating which fields of the credential can be selectively disclosed.",
-						"example": {
-							"first_name": false,
-							"last_name": false,
-							"age": {
-								"over_18": true,
-								"over_21": true,
-								"over_65": true
-							}
-						}
-					}
-				},
-				"required": [
-					"credentialSupportedId",
-					"format",
-					"issuer",
-					"payload",
-					"disclosureFrame"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"OpenId4VciPreAuthorizedCodeFlowConfig": {
-				"properties": {
-					"preAuthorizedCode": {
-						"type": "string"
-					},
-					"userPinRequired": {
-						"type": "boolean"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Pick_OpenId4VciCreateCredentialOfferOptions.Exclude_keyofOpenId4VciCreateCredentialOfferOptions.offeredCredentials__": {
-				"properties": {
-					"baseUri": {
-						"type": "string",
-						"description": "baseUri for the credential offer uri. By default `openid-credential-offer://` will be used\nif no value is provided. If a value is provided, make sure it contains the scheme as well as `://`."
-					},
-					"preAuthorizedCodeFlowConfig": {
-						"$ref": "#/components/schemas/OpenId4VciPreAuthorizedCodeFlowConfig"
-					},
-					"issuanceMetadata": {
-						"$ref": "#/components/schemas/Record_string.unknown_",
-						"description": "Metadata about the issuance, that will be stored in the issuance session record and\npassed to the credential request to credential mapper. This can be used to e.g. store an\nuser identifier so user data can be fetched in the credential mapper, or the actual credential\ndata."
-					}
-				},
-				"required": [
-					"preAuthorizedCodeFlowConfig"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"OpenId4VcIssuanceSessionsCreateOfferOptions": {
-				"properties": {
-					"baseUri": {
-						"type": "string",
-						"description": "baseUri for the credential offer uri. By default `openid-credential-offer://` will be used\nif no value is provided. If a value is provided, make sure it contains the scheme as well as `://`."
-					},
-					"preAuthorizedCodeFlowConfig": {
-						"$ref": "#/components/schemas/OpenId4VciPreAuthorizedCodeFlowConfig"
-					},
-					"issuanceMetadata": {
-						"$ref": "#/components/schemas/Record_string.unknown_",
-						"description": "Metadata about the issuance, that will be stored in the issuance session record and\npassed to the credential request to credential mapper. This can be used to e.g. store an\nuser identifier so user data can be fetched in the credential mapper, or the actual credential\ndata."
-					},
-					"publicIssuerId": {
-						"$ref": "#/components/schemas/PublicIssuerId"
-					},
-					"credentials": {
-						"items": {
-							"$ref": "#/components/schemas/OpenId4VcIssuanceSessionCreateOfferSdJwtCredentialOptions"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"preAuthorizedCodeFlowConfig",
-					"publicIssuerId",
-					"credentials"
-				],
-				"type": "object",
-				"additionalProperties": false,
-				"example": {
-					"publicIssuerId": "a868257d-7149-4d4d-a52c-78f3197ee538",
-					"preAuthorizedCodeFlowConfig": {
-						"userPinRequired": false
-					},
-					"credentials": [
-						{
-							"credentialSupportedId": "ExampleCredentialSdJwtVc",
-							"format": "vc+sd-jwt",
-							"issuer": {
-								"method": "did",
-								"didUrl": "did:key:z6MkgViwfstCL1L9i8tgsdAYEu5A62W5mA9DcmSygVVVLFuU#z6MkgViwfstCL1L9i8tgsdAYEu5A62W5mA9DcmSygVVVLFuU"
-							},
-							"payload": {
-								"first_name": "John",
-								"last_name": "Doe",
-								"age": {
-									"over_18": true,
-									"over_21": true,
-									"over_65": false
-								}
-							},
-							"disclosureFrame": {
-								"first_name": false,
-								"last_name": false,
-								"age": {
-									"over_18": true,
-									"over_21": true,
-									"over_65": true
-								}
-							}
-						}
-					]
-				}
-			},
-			"ThreadId": {
-				"type": "string",
-				"example": "ea4e5e69-fc04-465a-90d2-9f8ff78aa71d"
-			},
-			"ProofState": {
-				"description": "Present Proof protocol states as defined in RFC 0037",
-				"enum": [
-					"proposal-sent",
-					"proposal-received",
-					"request-sent",
-					"request-received",
-					"presentation-sent",
-					"presentation-received",
-					"declined",
-					"abandoned",
-					"done"
-				],
-				"type": "string"
-			},
-			"ProofRole": {
-				"enum": [
-					"verifier",
-					"prover"
-				],
-				"type": "string"
-			},
-			"AutoAcceptProof": {
-				"description": "Typing of the state for auto acceptance",
-				"enum": [
-					"always",
-					"contentApproved",
-					"never"
-				],
-				"type": "string"
-			},
-			"DidCommProofExchangeRecord": {
-				"properties": {
-					"id": {
-						"$ref": "#/components/schemas/RecordId"
-					},
-					"createdAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"updatedAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"type": {
-						"type": "string"
-					},
-					"connectionId": {
-						"$ref": "#/components/schemas/RecordId"
-					},
-					"threadId": {
-						"$ref": "#/components/schemas/ThreadId"
-					},
-					"parentThreadId": {
-						"$ref": "#/components/schemas/ThreadId"
-					},
-					"state": {
-						"$ref": "#/components/schemas/ProofState"
-					},
-					"role": {
-						"$ref": "#/components/schemas/ProofRole"
-					},
-					"autoAcceptProof": {
-						"$ref": "#/components/schemas/AutoAcceptProof"
-					},
-					"errorMessage": {
-						"type": "string"
-					},
-					"protocolVersion": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"id",
-					"createdAt",
-					"type",
-					"threadId",
-					"state",
-					"role",
-					"protocolVersion"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"ProofFormatDataMessagePayload_ProofFormats.proposal_": {
-				"properties": {},
-				"type": "object",
-				"description": "Get the format data payload for a specific message from a list of ProofFormat interfaces and a message\n\nFor an indy offer, this resolves to the proof request format as defined here:\nhttps://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0592-indy-attachments#proof-request-format"
-			},
-			"ProofFormatDataMessagePayload_ProofFormats.request_": {
-				"properties": {},
-				"type": "object",
-				"description": "Get the format data payload for a specific message from a list of ProofFormat interfaces and a message\n\nFor an indy offer, this resolves to the proof request format as defined here:\nhttps://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0592-indy-attachments#proof-request-format"
-			},
-			"ProofFormatDataMessagePayload_ProofFormats.presentation_": {
-				"properties": {},
-				"type": "object",
-				"description": "Get the format data payload for a specific message from a list of ProofFormat interfaces and a message\n\nFor an indy offer, this resolves to the proof request format as defined here:\nhttps://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0592-indy-attachments#proof-request-format"
-			},
-			"DidCommProofsGetFormatDataResponse": {
-				"properties": {
-					"presentation": {
-						"$ref": "#/components/schemas/ProofFormatDataMessagePayload_ProofFormats.presentation_"
-					},
-					"request": {
-						"$ref": "#/components/schemas/ProofFormatDataMessagePayload_ProofFormats.request_"
-					},
-					"proposal": {
-						"$ref": "#/components/schemas/ProofFormatDataMessagePayload_ProofFormats.proposal_"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"ProofProtocolVersion": {
-				"type": "string",
-				"enum": [
-					"v1",
-					"v2"
-				]
-			},
-			"AnonCredsPresentationPreviewAttribute": {
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"credentialDefinitionId": {
-						"type": "string"
-					},
-					"mimeType": {
-						"type": "string"
-					},
-					"value": {
-						"type": "string"
-					},
-					"referent": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"name"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AnonCredsPredicateType": {
-				"type": "string",
-				"enum": [
-					">=",
-					">",
-					"<=",
-					"<"
-				]
-			},
-			"AnonCredsPresentationPreviewPredicate": {
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"credentialDefinitionId": {
-						"type": "string"
-					},
-					"predicate": {
-						"$ref": "#/components/schemas/AnonCredsPredicateType"
-					},
-					"threshold": {
-						"type": "number",
-						"format": "double"
-					}
-				},
-				"required": [
-					"name",
-					"credentialDefinitionId",
-					"predicate",
-					"threshold"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AnonCredsNonRevokedInterval": {
-				"properties": {
-					"from": {
-						"type": "number",
-						"format": "double"
-					},
-					"to": {
-						"type": "number",
-						"format": "double"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AnonCredsProposeProofFormat": {
-				"description": "Interface for creating an anoncreds proof proposal.",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"version": {
-						"type": "string"
-					},
-					"attributes": {
-						"items": {
-							"$ref": "#/components/schemas/AnonCredsPresentationPreviewAttribute"
-						},
-						"type": "array"
-					},
-					"predicates": {
-						"items": {
-							"$ref": "#/components/schemas/AnonCredsPresentationPreviewPredicate"
-						},
-						"type": "array"
-					},
-					"nonRevokedInterval": {
-						"$ref": "#/components/schemas/AnonCredsNonRevokedInterval"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Pick_ProposeProofOptions.Exclude_keyofProposeProofOptions.proofFormats-or-protocolVersion__": {
-				"properties": {
-					"connectionId": {
-						"type": "string"
-					},
-					"goalCode": {
-						"type": "string"
-					},
-					"parentThreadId": {
-						"type": "string"
-					},
-					"autoAcceptProof": {
-						"$ref": "#/components/schemas/AutoAcceptProof"
-					},
-					"comment": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"connectionId"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"DidCommProofsProposeProofOptions": {
-				"properties": {
-					"connectionId": {
-						"type": "string"
-					},
-					"goalCode": {
-						"type": "string"
-					},
-					"parentThreadId": {
-						"type": "string"
-					},
-					"autoAcceptProof": {
-						"$ref": "#/components/schemas/AutoAcceptProof"
-					},
-					"comment": {
-						"type": "string"
-					},
-					"protocolVersion": {
-						"$ref": "#/components/schemas/ProofProtocolVersion"
-					},
-					"proofFormats": {
-						"properties": {
-							"anoncreds": {
-								"$ref": "#/components/schemas/AnonCredsProposeProofFormat"
-							},
-							"indy": {
-								"$ref": "#/components/schemas/AnonCredsProposeProofFormat"
-							}
-						},
-						"type": "object"
-					}
-				},
-				"required": [
-					"connectionId",
-					"protocolVersion",
-					"proofFormats"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AcceptAnonCredsProposalOptions": {
-				"properties": {},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Pick_AcceptProofProposalOptions.Exclude_keyofAcceptProofProposalOptions.proofFormats-or-proofRecordId__": {
-				"properties": {
-					"goalCode": {
-						"type": "string"
-					},
-					"autoAcceptProof": {
-						"$ref": "#/components/schemas/AutoAcceptProof"
-					},
-					"comment": {
-						"type": "string"
-					},
-					"willConfirm": {
-						"type": "boolean",
-						"default": true
-					}
-				},
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"DidCommProofsAcceptProposalOptions": {
-				"properties": {
-					"goalCode": {
-						"type": "string"
-					},
-					"autoAcceptProof": {
-						"$ref": "#/components/schemas/AutoAcceptProof"
-					},
-					"comment": {
-						"type": "string"
-					},
-					"willConfirm": {
-						"type": "boolean",
-						"default": true
-					},
-					"protocolVersion": {
-						"$ref": "#/components/schemas/ProofProtocolVersion"
-					},
-					"proofFormats": {
-						"properties": {
-							"anoncreds": {
-								"$ref": "#/components/schemas/AcceptAnonCredsProposalOptions"
-							},
-							"indy": {
-								"$ref": "#/components/schemas/AcceptAnonCredsProposalOptions"
-							}
-						},
-						"type": "object"
-					}
-				},
-				"required": [
-					"protocolVersion"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"PlaintextMessage": {
-				"properties": {
-					"@type": {
-						"type": "string"
-					},
-					"@id": {
-						"type": "string"
-					},
-					"~thread": {
-						"properties": {
-							"pthid": {
-								"type": "string"
-							},
-							"thid": {
-								"type": "string"
-							}
-						},
-						"type": "object"
-					}
-				},
-				"required": [
-					"@type",
-					"@id"
-				],
-				"type": "object",
-				"additionalProperties": {}
-			},
-			"DidCommProofsCreateRequestResponse": {
-				"properties": {
-					"message": {
-						"$ref": "#/components/schemas/PlaintextMessage"
-					},
-					"proofExchange": {
-						"$ref": "#/components/schemas/DidCommProofExchangeRecord"
-					}
-				},
-				"required": [
-					"message",
-					"proofExchange"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AnonCredsProofRequestRestrictionOptions": {
-				"properties": {
-					"schema_id": {
-						"type": "string"
-					},
-					"schema_issuer_id": {
-						"type": "string"
-					},
-					"schema_name": {
-						"type": "string"
-					},
-					"schema_version": {
-						"type": "string"
-					},
-					"issuer_id": {
-						"type": "string"
-					},
-					"cred_def_id": {
-						"type": "string"
-					},
-					"rev_reg_id": {
-						"type": "string"
-					},
-					"schema_issuer_did": {
-						"type": "string"
-					},
-					"issuer_did": {
-						"type": "string"
-					},
-					"attributeValues": {
-						"properties": {},
-						"additionalProperties": {
-							"type": "string"
-						},
-						"type": "object"
-					},
-					"attributeMarkers": {
-						"properties": {},
-						"additionalProperties": {
-							"type": "boolean"
-						},
-						"type": "object"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AnonCredsRequestedAttributeOptions": {
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"names": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"restrictions": {
-						"items": {
-							"$ref": "#/components/schemas/AnonCredsProofRequestRestrictionOptions"
-						},
-						"type": "array"
-					},
-					"non_revoked": {
-						"$ref": "#/components/schemas/AnonCredsNonRevokedInterval"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AnonCredsRequestedPredicateOptions": {
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"p_type": {
-						"$ref": "#/components/schemas/AnonCredsPredicateType"
-					},
-					"p_value": {
-						"type": "number",
-						"format": "double"
-					},
-					"restrictions": {
-						"items": {
-							"$ref": "#/components/schemas/AnonCredsProofRequestRestrictionOptions"
-						},
-						"type": "array"
-					},
-					"non_revoked": {
-						"$ref": "#/components/schemas/AnonCredsNonRevokedInterval"
-					}
-				},
-				"required": [
-					"name",
-					"p_type",
-					"p_value"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AnonCredsRequestProofFormatOptions": {
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"version": {
-						"type": "string"
-					},
-					"non_revoked": {
-						"$ref": "#/components/schemas/AnonCredsNonRevokedInterval"
-					},
-					"requested_attributes": {
-						"properties": {},
-						"additionalProperties": {
-							"$ref": "#/components/schemas/AnonCredsRequestedAttributeOptions"
-						},
-						"type": "object"
-					},
-					"requested_predicates": {
-						"properties": {},
-						"additionalProperties": {
-							"$ref": "#/components/schemas/AnonCredsRequestedPredicateOptions"
-						},
-						"type": "object"
-					}
-				},
-				"required": [
-					"name",
-					"version"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Pick_CreateProofRequestOptions.Exclude_keyofCreateProofRequestOptions.proofFormats-or-protocolVersion__": {
-				"properties": {
-					"goalCode": {
-						"type": "string"
-					},
-					"parentThreadId": {
-						"type": "string"
-					},
-					"autoAcceptProof": {
-						"$ref": "#/components/schemas/AutoAcceptProof"
-					},
-					"comment": {
-						"type": "string"
-					},
-					"willConfirm": {
-						"type": "boolean",
-						"default": true
-					}
-				},
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"DidCommProofsCreateRequestOptions": {
-				"properties": {
-					"goalCode": {
-						"type": "string"
-					},
-					"parentThreadId": {
-						"type": "string"
-					},
-					"autoAcceptProof": {
-						"$ref": "#/components/schemas/AutoAcceptProof"
-					},
-					"comment": {
-						"type": "string"
-					},
-					"willConfirm": {
-						"type": "boolean",
-						"default": true
-					},
-					"protocolVersion": {
-						"$ref": "#/components/schemas/ProofProtocolVersion"
-					},
-					"proofFormats": {
-						"properties": {
-							"anoncreds": {
-								"$ref": "#/components/schemas/AnonCredsRequestProofFormatOptions"
-							},
-							"indy": {
-								"$ref": "#/components/schemas/AnonCredsRequestProofFormatOptions"
-							}
-						},
-						"type": "object"
-					}
-				},
-				"required": [
-					"protocolVersion",
-					"proofFormats"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"DidCommProofsSendRequestOptions": {
-				"properties": {
-					"goalCode": {
-						"type": "string"
-					},
-					"parentThreadId": {
-						"type": "string"
-					},
-					"autoAcceptProof": {
-						"$ref": "#/components/schemas/AutoAcceptProof"
-					},
-					"comment": {
-						"type": "string"
-					},
-					"willConfirm": {
-						"type": "boolean",
-						"default": true
-					},
-					"protocolVersion": {
-						"$ref": "#/components/schemas/ProofProtocolVersion"
-					},
-					"proofFormats": {
-						"properties": {
-							"anoncreds": {
-								"$ref": "#/components/schemas/AnonCredsRequestProofFormatOptions"
-							},
-							"indy": {
-								"$ref": "#/components/schemas/AnonCredsRequestProofFormatOptions"
-							}
-						},
-						"type": "object"
-					},
-					"connectionId": {
-						"$ref": "#/components/schemas/RecordId"
-					}
-				},
-				"required": [
-					"protocolVersion",
-					"proofFormats",
-					"connectionId"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Record_string.string-or-number_": {
-				"properties": {},
-				"additionalProperties": {
-					"anyOf": [
-						{
-							"type": "string"
-						},
-						{
-							"type": "number",
-							"format": "double"
-						}
-					]
-				},
-				"type": "object",
-				"description": "Construct a type with a set of properties K of type T"
-			},
-			"AnonCredsClaimRecord": {
-				"$ref": "#/components/schemas/Record_string.string-or-number_"
-			},
-			"AnonCredsCredentialInfo": {
-				"properties": {
-					"credentialId": {
-						"type": "string"
-					},
-					"attributes": {
-						"$ref": "#/components/schemas/AnonCredsClaimRecord"
-					},
-					"schemaId": {
-						"type": "string"
-					},
-					"credentialDefinitionId": {
-						"type": "string"
-					},
-					"revocationRegistryId": {
-						"type": "string",
-						"nullable": true
-					},
-					"credentialRevocationId": {
-						"type": "string",
-						"nullable": true
-					},
-					"methodName": {
-						"type": "string"
-					},
-					"linkSecretId": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"credentialId",
-					"attributes",
-					"schemaId",
-					"credentialDefinitionId",
-					"revocationRegistryId",
-					"credentialRevocationId",
-					"methodName",
-					"linkSecretId"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AnonCredsRequestedAttributeMatch": {
-				"properties": {
-					"credentialId": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "number",
-						"format": "double"
-					},
-					"revealed": {
-						"type": "boolean"
-					},
-					"credentialInfo": {
-						"$ref": "#/components/schemas/AnonCredsCredentialInfo"
-					},
-					"revoked": {
-						"type": "boolean"
-					}
-				},
-				"required": [
-					"credentialId",
-					"revealed",
-					"credentialInfo"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Record_string.AnonCredsRequestedAttributeMatch_": {
-				"properties": {},
-				"additionalProperties": {
-					"$ref": "#/components/schemas/AnonCredsRequestedAttributeMatch"
-				},
-				"type": "object",
-				"description": "Construct a type with a set of properties K of type T"
-			},
-			"AnonCredsRequestedPredicateMatch": {
-				"properties": {
-					"credentialId": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "number",
-						"format": "double"
-					},
-					"credentialInfo": {
-						"$ref": "#/components/schemas/AnonCredsCredentialInfo"
-					},
-					"revoked": {
-						"type": "boolean"
-					}
-				},
-				"required": [
-					"credentialId",
-					"credentialInfo"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Record_string.AnonCredsRequestedPredicateMatch_": {
-				"properties": {},
-				"additionalProperties": {
-					"$ref": "#/components/schemas/AnonCredsRequestedPredicateMatch"
-				},
-				"type": "object",
-				"description": "Construct a type with a set of properties K of type T"
-			},
-			"Record_string.string_": {
-				"properties": {},
-				"additionalProperties": {
-					"type": "string"
-				},
-				"type": "object",
-				"description": "Construct a type with a set of properties K of type T"
-			},
-			"AnonCredsSelectedCredentials": {
-				"properties": {
-					"attributes": {
-						"$ref": "#/components/schemas/Record_string.AnonCredsRequestedAttributeMatch_"
-					},
-					"predicates": {
-						"$ref": "#/components/schemas/Record_string.AnonCredsRequestedPredicateMatch_"
-					},
-					"selfAttestedAttributes": {
-						"$ref": "#/components/schemas/Record_string.string_"
-					}
-				},
-				"required": [
-					"attributes",
-					"predicates",
-					"selfAttestedAttributes"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Pick_AcceptProofRequestOptions.Exclude_keyofAcceptProofRequestOptions.proofFormats-or-proofRecordId__": {
-				"properties": {
-					"goalCode": {
-						"type": "string"
-					},
-					"autoAcceptProof": {
-						"$ref": "#/components/schemas/AutoAcceptProof"
-					},
-					"comment": {
-						"type": "string"
-					},
-					"willConfirm": {
-						"type": "boolean",
-						"default": true
-					},
-					"useReturnRoute": {
-						"type": "boolean",
-						"description": "whether to enable return routing on the send presentation message. This value only\nhas an effect for connectionless exchanges."
-					}
-				},
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"DidCommProofsAcceptRequestOptions": {
-				"properties": {
-					"goalCode": {
-						"type": "string"
-					},
-					"autoAcceptProof": {
-						"$ref": "#/components/schemas/AutoAcceptProof"
-					},
-					"comment": {
-						"type": "string"
-					},
-					"willConfirm": {
-						"type": "boolean",
-						"default": true
-					},
-					"useReturnRoute": {
-						"type": "boolean",
-						"description": "whether to enable return routing on the send presentation message. This value only\nhas an effect for connectionless exchanges."
-					},
-					"proofFormats": {
-						"properties": {
-							"anoncreds": {
-								"$ref": "#/components/schemas/AnonCredsSelectedCredentials"
-							},
-							"indy": {
-								"$ref": "#/components/schemas/AnonCredsSelectedCredentials"
-							}
-						},
-						"type": "object"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"OutOfBandRole": {
-				"enum": [
-					"sender",
-					"receiver"
-				],
-				"type": "string"
-			},
-			"OutOfBandState": {
-				"enum": [
-					"initial",
-					"await-response",
-					"prepare-response",
-					"done"
-				],
-				"type": "string"
-			},
-			"DidCommOutOfBandRecord": {
-				"properties": {
-					"id": {
-						"$ref": "#/components/schemas/RecordId"
-					},
-					"createdAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"updatedAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"type": {
-						"type": "string"
-					},
-					"outOfBandInvitation": {
-						"$ref": "#/components/schemas/PlaintextMessage",
-						"description": "The out of band invitation"
-					},
-					"role": {
-						"$ref": "#/components/schemas/OutOfBandRole",
-						"description": "Our role in the out of band exchange"
-					},
-					"state": {
-						"$ref": "#/components/schemas/OutOfBandState",
-						"description": "State of the out of band invitation"
-					},
-					"alias": {
-						"type": "string",
-						"description": "Alias for the connection(s) created based on the out of band invitation",
-						"example": "My Connection"
-					},
-					"reusable": {
-						"type": "boolean",
-						"description": "Whether the out of band invitation is reusable",
-						"example": true
-					},
-					"autoAcceptConnection": {
-						"type": "boolean",
-						"description": "Whether to auto accept the out of band invitation.\nIf not defined agent config will be used.",
-						"example": true
-					},
-					"mediatorId": {
-						"$ref": "#/components/schemas/RecordId",
-						"description": "Mediator used for the out of band exchange"
-					},
-					"reuseConnectionId": {
-						"$ref": "#/components/schemas/RecordId",
-						"description": "The id of the connection that was reused for the out of band exchange"
-					}
-				},
-				"required": [
-					"id",
-					"createdAt",
-					"type",
-					"outOfBandInvitation",
-					"role",
-					"state",
-					"reusable"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"DidCommOutOfBandCreateInvitationResponse": {
-				"properties": {
-					"invitation": {
-						"$ref": "#/components/schemas/PlaintextMessage"
-					},
-					"outOfBandRecord": {
-						"$ref": "#/components/schemas/DidCommOutOfBandRecord"
-					},
-					"invitationUrl": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"invitation",
-					"outOfBandRecord",
-					"invitationUrl"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"HandshakeProtocol": {
-				"description": "Enum values should be sorted based on order of preference. Values will be\nincluded in this order when creating out of band invitations.",
-				"enum": [
-					"https://didcomm.org/didexchange/1.x",
-					"https://didcomm.org/connections/1.x"
-				],
-				"type": "string"
-			},
-			"Pick_CreateOutOfBandInvitationConfig.Exclude_keyofCreateOutOfBandInvitationConfig.routing-or-appendedAttachments-or-messages__": {
-				"properties": {
-					"label": {
-						"type": "string"
-					},
-					"goalCode": {
-						"type": "string"
-					},
-					"alias": {
-						"type": "string"
-					},
-					"imageUrl": {
-						"type": "string"
-					},
-					"goal": {
-						"type": "string"
-					},
-					"handshake": {
-						"type": "boolean"
-					},
-					"handshakeProtocols": {
-						"items": {
-							"$ref": "#/components/schemas/HandshakeProtocol"
-						},
-						"type": "array"
-					},
-					"multiUseInvitation": {
-						"type": "boolean"
-					},
-					"autoAcceptConnection": {
-						"type": "boolean"
-					}
-				},
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"DidCommOutOfBandCreateInvitationOptions": {
-				"properties": {
-					"label": {
-						"type": "string"
-					},
-					"goalCode": {
-						"type": "string"
-					},
-					"alias": {
-						"type": "string"
-					},
-					"imageUrl": {
-						"type": "string"
-					},
-					"goal": {
-						"type": "string"
-					},
-					"handshake": {
-						"type": "boolean"
-					},
-					"handshakeProtocols": {
-						"items": {
-							"$ref": "#/components/schemas/HandshakeProtocol"
-						},
-						"type": "array"
-					},
-					"multiUseInvitation": {
-						"type": "boolean"
-					},
-					"autoAcceptConnection": {
-						"type": "boolean"
-					},
-					"messages": {
-						"items": {
-							"$ref": "#/components/schemas/PlaintextMessage"
-						},
-						"type": "array"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Pick_CreateLegacyInvitationConfig.Exclude_keyofCreateLegacyInvitationConfig.routing__": {
-				"properties": {
-					"label": {
-						"type": "string"
-					},
-					"alias": {
-						"type": "string"
-					},
-					"imageUrl": {
-						"type": "string"
-					},
-					"multiUseInvitation": {
-						"type": "boolean"
-					},
-					"autoAcceptConnection": {
-						"type": "boolean"
-					}
-				},
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"DidCommOutOfBandCreateLegacyConnectionInvitationOptions": {
-				"properties": {
-					"label": {
-						"type": "string"
-					},
-					"alias": {
-						"type": "string"
-					},
-					"imageUrl": {
-						"type": "string"
-					},
-					"multiUseInvitation": {
-						"type": "boolean"
-					},
-					"autoAcceptConnection": {
-						"type": "boolean"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"DidCommOutOfBandCreateLegacyConnectionlessInvitationOptions": {
-				"properties": {
-					"message": {
-						"$ref": "#/components/schemas/PlaintextMessage"
-					},
-					"domain": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"message",
-					"domain"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Pick_ReceiveOutOfBandInvitationConfig.Exclude_keyofReceiveOutOfBandInvitationConfig.routing__": {
-				"properties": {
-					"label": {
-						"type": "string"
-					},
-					"alias": {
-						"type": "string"
-					},
-					"imageUrl": {
-						"type": "string"
-					},
-					"autoAcceptConnection": {
-						"type": "boolean"
-					},
-					"autoAcceptInvitation": {
-						"type": "boolean"
-					},
-					"reuseConnection": {
-						"type": "boolean"
-					},
-					"acceptInvitationTimeoutMs": {
-						"type": "number",
-						"format": "double"
-					},
-					"ourDid": {
-						"type": "string"
-					}
-				},
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"DidCommOutOfBandReceiveInvitationOptions": {
-				"properties": {
-					"label": {
-						"type": "string"
-					},
-					"alias": {
-						"type": "string"
-					},
-					"imageUrl": {
-						"type": "string"
-					},
-					"autoAcceptConnection": {
-						"type": "boolean"
-					},
-					"autoAcceptInvitation": {
-						"type": "boolean"
-					},
-					"reuseConnection": {
-						"type": "boolean"
-					},
-					"acceptInvitationTimeoutMs": {
-						"type": "number",
-						"format": "double"
-					},
-					"ourDid": {
-						"type": "string"
-					},
-					"invitation": {
-						"anyOf": [
-							{
-								"$ref": "#/components/schemas/PlaintextMessage"
-							},
-							{
-								"type": "string"
-							}
-						]
-					}
-				},
-				"required": [
-					"invitation"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"DidCommOutOfBandAcceptInvitationOptions": {
-				"properties": {
-					"autoAcceptConnection": {
-						"type": "boolean"
-					},
-					"reuseConnection": {
-						"type": "boolean"
-					},
-					"label": {
-						"type": "string"
-					},
-					"alias": {
-						"type": "string"
-					},
-					"imageUrl": {
-						"type": "string"
-					},
-					"timeoutMs": {
-						"type": "number",
-						"format": "double"
-					},
-					"ourDid": {
-						"$ref": "#/components/schemas/Did"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"CredentialState": {
-				"description": "Issue Credential states as defined in RFC 0036 and RFC 0453",
-				"enum": [
-					"proposal-sent",
-					"proposal-received",
-					"offer-sent",
-					"offer-received",
-					"declined",
-					"request-sent",
-					"request-received",
-					"credential-issued",
-					"credential-received",
-					"done",
-					"abandoned"
-				],
-				"type": "string"
-			},
-			"CredentialRole": {
-				"enum": [
-					"issuer",
-					"holder"
-				],
-				"type": "string"
-			},
-			"AutoAcceptCredential": {
-				"description": "Typing of the state for auto acceptance",
-				"enum": [
-					"always",
-					"contentApproved",
-					"never"
-				],
-				"type": "string"
-			},
-			"CredentialRecordBinding": {
-				"properties": {
-					"credentialRecordType": {
-						"type": "string"
-					},
-					"credentialRecordId": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"credentialRecordType",
-					"credentialRecordId"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"CredentialPreviewAttributeOptions": {
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"mimeType": {
-						"type": "string"
-					},
-					"value": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"name",
-					"value"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"DidCommCredentialExchangeRecord": {
-				"properties": {
-					"id": {
-						"$ref": "#/components/schemas/RecordId"
-					},
-					"createdAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"updatedAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"type": {
-						"type": "string"
-					},
-					"connectionId": {
-						"$ref": "#/components/schemas/RecordId"
-					},
-					"threadId": {
-						"$ref": "#/components/schemas/ThreadId"
-					},
-					"parentThreadId": {
-						"$ref": "#/components/schemas/ThreadId"
-					},
-					"state": {
-						"$ref": "#/components/schemas/CredentialState"
-					},
-					"role": {
-						"$ref": "#/components/schemas/CredentialRole"
-					},
-					"autoAcceptCredential": {
-						"$ref": "#/components/schemas/AutoAcceptCredential"
-					},
-					"revocationNotification": {
-						"properties": {
-							"comment": {
-								"type": "string"
-							},
-							"revocationDate": {
-								"type": "string",
-								"format": "date-time"
-							}
-						},
-						"required": [
-							"revocationDate"
-						],
-						"type": "object"
-					},
-					"errorMessage": {
-						"type": "string"
-					},
-					"protocolVersion": {
-						"type": "string"
-					},
-					"credentials": {
-						"items": {
-							"$ref": "#/components/schemas/CredentialRecordBinding"
-						},
-						"type": "array"
-					},
-					"credentialAttributes": {
-						"items": {
-							"$ref": "#/components/schemas/CredentialPreviewAttributeOptions"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"id",
-					"createdAt",
-					"type",
-					"threadId",
-					"state",
-					"role",
-					"protocolVersion",
-					"credentials"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Pick_AnonCredsCredentialProposalFormat.Exclude_keyofAnonCredsCredentialProposalFormat.schema_issuer_id-or-issuer_id__": {
-				"properties": {
-					"schema_name": {
-						"type": "string"
-					},
-					"schema_version": {
-						"type": "string"
-					},
-					"schema_id": {
-						"type": "string"
-					},
-					"cred_def_id": {
-						"type": "string"
-					},
-					"schema_issuer_did": {
-						"type": "string"
-					},
-					"issuer_did": {
-						"type": "string"
-					}
-				},
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"Omit_AnonCredsCredentialProposalFormat.schema_issuer_id-or-issuer_id_": {
-				"$ref": "#/components/schemas/Pick_AnonCredsCredentialProposalFormat.Exclude_keyofAnonCredsCredentialProposalFormat.schema_issuer_id-or-issuer_id__",
-				"description": "Construct a type with the properties of T except for those in type K."
-			},
-			"LegacyIndyCredentialProposalFormat": {
-				"$ref": "#/components/schemas/Omit_AnonCredsCredentialProposalFormat.schema_issuer_id-or-issuer_id_"
-			},
-			"AnonCredsCredentialProposalFormat": {
-				"properties": {
-					"schema_issuer_id": {
-						"type": "string"
-					},
-					"schema_name": {
-						"type": "string"
-					},
-					"schema_version": {
-						"type": "string"
-					},
-					"schema_id": {
-						"type": "string"
-					},
-					"cred_def_id": {
-						"type": "string"
-					},
-					"issuer_id": {
-						"type": "string"
-					},
-					"schema_issuer_did": {
-						"type": "string"
-					},
-					"issuer_did": {
-						"type": "string"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"CredentialFormatDataMessagePayload_CredentialFormats.proposal_": {
-				"properties": {
-					"indy": {
-						"$ref": "#/components/schemas/LegacyIndyCredentialProposalFormat"
-					},
-					"anoncreds": {
-						"$ref": "#/components/schemas/AnonCredsCredentialProposalFormat"
-					}
-				},
-				"type": "object",
-				"description": "Get the format data payload for a specific message from a list of CredentialFormat interfaces and a message\n\nFor an indy offer, this resolves to the cred abstract format as defined here:\nhttps://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0592-indy-attachments#cred-abstract-format"
-			},
-			"LegacyIndyCredentialRequest": {
-				"properties": {
-					"prover_did": {
-						"type": "string"
-					},
-					"entropy": {
-						"type": "string"
-					},
-					"cred_def_id": {
-						"type": "string"
-					},
-					"blinded_ms": {
-						"$ref": "#/components/schemas/Record_string.unknown_"
-					},
-					"blinded_ms_correctness_proof": {
-						"$ref": "#/components/schemas/Record_string.unknown_"
-					},
-					"nonce": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"cred_def_id",
-					"blinded_ms",
-					"blinded_ms_correctness_proof",
-					"nonce",
-					"prover_did"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AnonCredsCredentialRequest": {
-				"properties": {
-					"prover_did": {
-						"type": "string"
-					},
-					"entropy": {
-						"type": "string"
-					},
-					"cred_def_id": {
-						"type": "string"
-					},
-					"blinded_ms": {
-						"$ref": "#/components/schemas/Record_string.unknown_"
-					},
-					"blinded_ms_correctness_proof": {
-						"$ref": "#/components/schemas/Record_string.unknown_"
-					},
-					"nonce": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"cred_def_id",
-					"blinded_ms",
-					"blinded_ms_correctness_proof",
-					"nonce"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"CredentialFormatDataMessagePayload_CredentialFormats.request_": {
-				"properties": {
-					"indy": {
-						"$ref": "#/components/schemas/LegacyIndyCredentialRequest"
-					},
-					"anoncreds": {
-						"$ref": "#/components/schemas/AnonCredsCredentialRequest"
-					}
-				},
-				"type": "object",
-				"description": "Get the format data payload for a specific message from a list of CredentialFormat interfaces and a message\n\nFor an indy offer, this resolves to the cred abstract format as defined here:\nhttps://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0592-indy-attachments#cred-abstract-format"
-			},
-			"AnonCredsCredentialOffer": {
-				"properties": {
-					"schema_id": {
-						"type": "string"
-					},
-					"cred_def_id": {
-						"type": "string"
-					},
-					"nonce": {
-						"type": "string"
-					},
-					"key_correctness_proof": {
-						"$ref": "#/components/schemas/Record_string.unknown_"
-					}
-				},
-				"required": [
-					"schema_id",
-					"cred_def_id",
-					"nonce",
-					"key_correctness_proof"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"CredentialFormatDataMessagePayload_CredentialFormats.offer_": {
-				"properties": {
-					"indy": {
-						"$ref": "#/components/schemas/AnonCredsCredentialOffer"
-					},
-					"anoncreds": {
-						"$ref": "#/components/schemas/AnonCredsCredentialOffer"
-					}
-				},
-				"type": "object",
-				"description": "Get the format data payload for a specific message from a list of CredentialFormat interfaces and a message\n\nFor an indy offer, this resolves to the cred abstract format as defined here:\nhttps://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0592-indy-attachments#cred-abstract-format"
-			},
-			"AnonCredsCredentialValue": {
-				"properties": {
-					"raw": {
-						"type": "string"
-					},
-					"encoded": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"raw",
-					"encoded"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Record_string.AnonCredsCredentialValue_": {
-				"properties": {},
-				"additionalProperties": {
-					"$ref": "#/components/schemas/AnonCredsCredentialValue"
-				},
-				"type": "object",
-				"description": "Construct a type with a set of properties K of type T"
-			},
-			"AnonCredsCredential": {
-				"properties": {
-					"schema_id": {
-						"type": "string"
-					},
-					"cred_def_id": {
-						"type": "string"
-					},
-					"rev_reg_id": {
-						"type": "string"
-					},
-					"values": {
-						"$ref": "#/components/schemas/Record_string.AnonCredsCredentialValue_"
-					},
-					"signature": {},
-					"signature_correctness_proof": {}
-				},
-				"required": [
-					"schema_id",
-					"cred_def_id",
-					"values",
-					"signature",
-					"signature_correctness_proof"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"CredentialFormatDataMessagePayload_CredentialFormats.credential_": {
-				"properties": {
-					"indy": {
-						"$ref": "#/components/schemas/AnonCredsCredential"
-					},
-					"anoncreds": {
-						"$ref": "#/components/schemas/AnonCredsCredential"
-					}
-				},
-				"type": "object",
-				"description": "Get the format data payload for a specific message from a list of CredentialFormat interfaces and a message\n\nFor an indy offer, this resolves to the cred abstract format as defined here:\nhttps://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0592-indy-attachments#cred-abstract-format"
-			},
-			"Pick_GetCredentialFormatDataReturn_CredentialFormats_.Exclude_keyofGetCredentialFormatDataReturn_CredentialFormats_.offerAttributes__": {
-				"properties": {
-					"proposal": {
-						"$ref": "#/components/schemas/CredentialFormatDataMessagePayload_CredentialFormats.proposal_"
-					},
-					"request": {
-						"$ref": "#/components/schemas/CredentialFormatDataMessagePayload_CredentialFormats.request_"
-					},
-					"offer": {
-						"$ref": "#/components/schemas/CredentialFormatDataMessagePayload_CredentialFormats.offer_"
-					},
-					"credential": {
-						"$ref": "#/components/schemas/CredentialFormatDataMessagePayload_CredentialFormats.credential_"
-					},
-					"proposalAttributes": {
-						"items": {
-							"$ref": "#/components/schemas/CredentialPreviewAttributeOptions"
-						},
-						"type": "array"
-					}
-				},
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"DidCommCredentialsGetFormatDataResponse": {
-				"properties": {
-					"proposal": {
-						"$ref": "#/components/schemas/CredentialFormatDataMessagePayload_CredentialFormats.proposal_"
-					},
-					"request": {
-						"$ref": "#/components/schemas/CredentialFormatDataMessagePayload_CredentialFormats.request_"
-					},
-					"offer": {
-						"$ref": "#/components/schemas/CredentialFormatDataMessagePayload_CredentialFormats.offer_"
-					},
-					"credential": {
-						"$ref": "#/components/schemas/CredentialFormatDataMessagePayload_CredentialFormats.credential_"
-					},
-					"proposalAttributes": {
-						"items": {
-							"$ref": "#/components/schemas/CredentialPreviewAttributeOptions"
-						},
-						"type": "array"
-					},
-					"offerAttributes": {
-						"items": {
-							"properties": {
-								"value": {
-									"type": "string"
-								},
-								"name": {
-									"type": "string"
-								},
-								"mime-type": {
-									"type": "string"
-								}
-							},
-							"required": [
-								"value",
-								"name"
-							],
-							"type": "object"
-						},
-						"type": "array"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"CredentialProtocolVersion": {
-				"type": "string",
-				"enum": [
-					"v1",
-					"v2"
-				]
-			},
-			"Pick_JwsGeneralFormat.Exclude_keyofJwsGeneralFormat.payload__": {
-				"properties": {
-					"header": {
-						"$ref": "#/components/schemas/Record_string.unknown_",
-						"description": "unprotected header"
-					},
-					"signature": {
-						"type": "string",
-						"description": "Base64url encoded signature"
-					},
-					"protected": {
-						"type": "string",
-						"description": "Base64url encoded protected header"
-					}
-				},
-				"required": [
-					"header",
-					"signature",
-					"protected"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"Omit_JwsGeneralFormat.payload_": {
-				"$ref": "#/components/schemas/Pick_JwsGeneralFormat.Exclude_keyofJwsGeneralFormat.payload__",
-				"description": "Construct a type with the properties of T except for those in type K."
-			},
-			"JwsDetachedFormat": {
-				"$ref": "#/components/schemas/Omit_JwsGeneralFormat.payload_"
-			},
-			"JwsFlattenedDetachedFormat": {
-				"properties": {
-					"signatures": {
-						"items": {
-							"$ref": "#/components/schemas/JwsDetachedFormat"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"signatures"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AttachmentData": {
-				"description": "A JSON object that gives access to the actual content of the attachment",
-				"properties": {
-					"base64": {
-						"type": "string",
-						"description": "Base64-encoded data, when representing arbitrary content inline instead of via links. Optional."
-					},
-					"json": {
-						"$ref": "#/components/schemas/JsonValue",
-						"description": "Directly embedded JSON data, when representing content inline instead of via links, and when the content is natively conveyable as JSON. Optional."
-					},
-					"links": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array",
-						"description": "A list of zero or more locations at which the content may be fetched. Optional."
-					},
-					"jws": {
-						"anyOf": [
-							{
-								"$ref": "#/components/schemas/JwsDetachedFormat"
-							},
-							{
-								"$ref": "#/components/schemas/JwsFlattenedDetachedFormat"
-							}
-						],
-						"description": "A JSON Web Signature over the content of the attachment. Optional."
-					},
-					"sha256": {
-						"type": "string",
-						"description": "The hash of the content. Optional."
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Attachment": {
-				"description": "Represents DIDComm attachment\nhttps://github.com/hyperledger/aries-rfcs/blob/master/concepts/0017-attachments/README.md",
-				"properties": {
-					"id": {
-						"type": "string"
-					},
-					"description": {
-						"type": "string",
-						"description": "An optional human-readable description of the content."
-					},
-					"filename": {
-						"type": "string",
-						"description": "A hint about the name that might be used if this attachment is persisted as a file. It is not required, and need not be unique. If this field is present and mime-type is not, the extension on the filename may be used to infer a MIME type."
-					},
-					"mimeType": {
-						"type": "string",
-						"description": "Describes the MIME type of the attached content. Optional but recommended."
-					},
-					"lastmodTime": {
-						"type": "string",
-						"format": "date-time",
-						"description": "A hint about when the content in this attachment was last modified."
-					},
-					"byteCount": {
-						"type": "number",
-						"format": "double",
-						"description": "Optional, and mostly relevant when content is included by reference instead of by value. Lets the receiver guess how expensive it will be, in time, bandwidth, and storage, to fully fetch the attachment."
-					},
-					"data": {
-						"$ref": "#/components/schemas/AttachmentData"
-					}
-				},
-				"required": [
-					"id",
-					"data"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"LinkedAttachment": {
-				"properties": {
-					"attributeName": {
-						"type": "string",
-						"description": "The name that will be used to generate the linked credential"
-					},
-					"attachment": {
-						"$ref": "#/components/schemas/Attachment",
-						"description": "The attachment that needs to be linked to the credential"
-					}
-				},
-				"required": [
-					"attributeName",
-					"attachment"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AnonCredsProposeCredentialFormat": {
-				"description": "This defines the module payload for calling CredentialsApi.createProposal\nor CredentialsApi.negotiateOffer",
-				"properties": {
-					"schemaIssuerId": {
-						"type": "string"
-					},
-					"schemaId": {
-						"type": "string"
-					},
-					"schemaName": {
-						"type": "string"
-					},
-					"schemaVersion": {
-						"type": "string"
-					},
-					"credentialDefinitionId": {
-						"type": "string"
-					},
-					"issuerId": {
-						"type": "string"
-					},
-					"attributes": {
-						"items": {
-							"$ref": "#/components/schemas/CredentialPreviewAttributeOptions"
-						},
-						"type": "array"
-					},
-					"linkedAttachments": {
-						"items": {
-							"$ref": "#/components/schemas/LinkedAttachment"
-						},
-						"type": "array"
-					},
-					"schemaIssuerDid": {
-						"type": "string"
-					},
-					"issuerDid": {
-						"type": "string"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Pick_AnonCredsProposeCredentialFormat.Exclude_keyofAnonCredsProposeCredentialFormat.schemaIssuerId-or-issuerId__": {
-				"properties": {
-					"schemaId": {
-						"type": "string"
-					},
-					"schemaName": {
-						"type": "string"
-					},
-					"schemaVersion": {
-						"type": "string"
-					},
-					"credentialDefinitionId": {
-						"type": "string"
-					},
-					"attributes": {
-						"items": {
-							"$ref": "#/components/schemas/CredentialPreviewAttributeOptions"
-						},
-						"type": "array"
-					},
-					"linkedAttachments": {
-						"items": {
-							"$ref": "#/components/schemas/LinkedAttachment"
-						},
-						"type": "array"
-					},
-					"schemaIssuerDid": {
-						"type": "string"
-					},
-					"issuerDid": {
-						"type": "string"
-					}
-				},
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"Omit_AnonCredsProposeCredentialFormat.schemaIssuerId-or-issuerId_": {
-				"$ref": "#/components/schemas/Pick_AnonCredsProposeCredentialFormat.Exclude_keyofAnonCredsProposeCredentialFormat.schemaIssuerId-or-issuerId__",
-				"description": "Construct a type with the properties of T except for those in type K."
-			},
-			"LegacyIndyProposeCredentialFormat": {
-				"$ref": "#/components/schemas/Omit_AnonCredsProposeCredentialFormat.schemaIssuerId-or-issuerId_",
-				"description": "This defines the module payload for calling CredentialsApi.createProposal\nor CredentialsApi.negotiateOffer\n\nNOTE: This doesn't include the `issuerId` and `schemaIssuerId` properties that are present in the newer format."
-			},
-			"ProposeCredentialOptions": {
-				"properties": {
-					"protocolVersion": {
-						"$ref": "#/components/schemas/CredentialProtocolVersion"
-					},
-					"credentialFormats": {
-						"properties": {
-							"indy": {
-								"anyOf": [
-									{
-										"$ref": "#/components/schemas/AnonCredsProposeCredentialFormat"
-									},
-									{
-										"$ref": "#/components/schemas/LegacyIndyProposeCredentialFormat"
-									}
-								]
-							},
-							"anoncreds": {
-								"anyOf": [
-									{
-										"$ref": "#/components/schemas/AnonCredsProposeCredentialFormat"
-									},
-									{
-										"$ref": "#/components/schemas/LegacyIndyProposeCredentialFormat"
-									}
-								]
-							}
-						},
-						"type": "object"
-					},
-					"autoAcceptCredential": {
-						"$ref": "#/components/schemas/AutoAcceptCredential"
-					},
-					"comment": {
-						"type": "string"
-					},
-					"connectionId": {
-						"$ref": "#/components/schemas/RecordId"
-					}
-				},
-				"required": [
-					"protocolVersion",
-					"credentialFormats",
-					"connectionId"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AnonCredsAcceptProposalFormat": {
-				"description": "This defines the module payload for calling CredentialsApi.acceptProposal",
-				"properties": {
-					"credentialDefinitionId": {
-						"type": "string"
-					},
-					"revocationRegistryDefinitionId": {
-						"type": "string"
-					},
-					"revocationRegistryIndex": {
-						"type": "number",
-						"format": "double"
-					},
-					"attributes": {
-						"items": {
-							"$ref": "#/components/schemas/CredentialPreviewAttributeOptions"
-						},
-						"type": "array"
-					},
-					"linkedAttachments": {
-						"items": {
-							"$ref": "#/components/schemas/LinkedAttachment"
-						},
-						"type": "array"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AcceptCredentialProposalOptions": {
-				"properties": {
-					"credentialFormats": {
-						"properties": {
-							"indy": {
-								"$ref": "#/components/schemas/AnonCredsAcceptProposalFormat"
-							},
-							"anoncreds": {
-								"$ref": "#/components/schemas/AnonCredsAcceptProposalFormat"
-							}
-						},
-						"type": "object"
-					},
-					"autoAcceptCredential": {
-						"$ref": "#/components/schemas/AutoAcceptCredential"
-					},
-					"comment": {
-						"type": "string"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"DidCommCredentialsCreateOfferResponse": {
-				"properties": {
-					"message": {
-						"$ref": "#/components/schemas/PlaintextMessage"
-					},
-					"credentialExchange": {
-						"$ref": "#/components/schemas/DidCommCredentialExchangeRecord"
-					}
-				},
-				"required": [
-					"message",
-					"credentialExchange"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AnonCredsOfferCredentialFormat": {
-				"description": "This defines the module payload for calling CredentialsApi.offerCredential\nor CredentialsApi.negotiateProposal",
-				"properties": {
-					"credentialDefinitionId": {
-						"type": "string"
-					},
-					"revocationRegistryDefinitionId": {
-						"type": "string"
-					},
-					"revocationRegistryIndex": {
-						"type": "number",
-						"format": "double"
-					},
-					"attributes": {
-						"items": {
-							"$ref": "#/components/schemas/CredentialPreviewAttributeOptions"
-						},
-						"type": "array"
-					},
-					"linkedAttachments": {
-						"items": {
-							"$ref": "#/components/schemas/LinkedAttachment"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"credentialDefinitionId",
-					"attributes"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"CredentialFormatPayload_CredentialFormats.createOffer_": {
-				"properties": {
-					"indy": {
-						"$ref": "#/components/schemas/AnonCredsOfferCredentialFormat"
-					},
-					"anoncreds": {
-						"$ref": "#/components/schemas/AnonCredsOfferCredentialFormat"
-					}
-				},
-				"type": "object",
-				"description": "Get the payload for a specific method from a list of CredentialFormat interfaces and a method"
-			},
-			"CreateOfferOptions": {
-				"properties": {
-					"protocolVersion": {
-						"$ref": "#/components/schemas/CredentialProtocolVersion"
-					},
-					"credentialFormats": {
-						"$ref": "#/components/schemas/CredentialFormatPayload_CredentialFormats.createOffer_"
-					},
-					"autoAcceptCredential": {
-						"$ref": "#/components/schemas/AutoAcceptCredential"
-					},
-					"comment": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"protocolVersion",
-					"credentialFormats"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"OfferCredentialOptions": {
-				"properties": {
-					"protocolVersion": {
-						"$ref": "#/components/schemas/CredentialProtocolVersion"
-					},
-					"credentialFormats": {
-						"$ref": "#/components/schemas/CredentialFormatPayload_CredentialFormats.createOffer_"
-					},
-					"autoAcceptCredential": {
-						"$ref": "#/components/schemas/AutoAcceptCredential"
-					},
-					"comment": {
-						"type": "string"
-					},
-					"connectionId": {
-						"$ref": "#/components/schemas/RecordId"
-					}
-				},
-				"required": [
-					"protocolVersion",
-					"credentialFormats",
-					"connectionId"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AnonCredsAcceptOfferFormat": {
-				"description": "This defines the module payload for calling CredentialsApi.acceptOffer. No options are available for this\nmethod, so it's an empty object",
-				"properties": {
-					"linkSecretId": {
-						"type": "string"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"CredentialFormatPayload_CredentialFormats.acceptOffer_": {
-				"properties": {
-					"indy": {
-						"$ref": "#/components/schemas/AnonCredsAcceptOfferFormat"
-					},
-					"anoncreds": {
-						"$ref": "#/components/schemas/AnonCredsAcceptOfferFormat"
-					}
-				},
-				"type": "object",
-				"description": "Get the payload for a specific method from a list of CredentialFormat interfaces and a method"
-			},
-			"AcceptCredentialOfferOptions": {
-				"properties": {
-					"credentialFormats": {
-						"$ref": "#/components/schemas/CredentialFormatPayload_CredentialFormats.acceptOffer_"
-					},
-					"autoAcceptCredential": {
-						"$ref": "#/components/schemas/AutoAcceptCredential"
-					},
-					"comment": {
-						"type": "string"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Record_string.never_": {
-				"properties": {},
-				"type": "object",
-				"description": "Construct a type with a set of properties K of type T"
-			},
-			"AnonCredsAcceptRequestFormat": {
-				"$ref": "#/components/schemas/Record_string.never_",
-				"description": "This defines the module payload for calling CredentialsApi.acceptRequest. No options are available for this\nmethod, so it's an empty object"
-			},
-			"CredentialFormatPayload_CredentialFormats.acceptRequest_": {
-				"properties": {
-					"indy": {
-						"$ref": "#/components/schemas/AnonCredsAcceptRequestFormat"
-					},
-					"anoncreds": {
-						"$ref": "#/components/schemas/AnonCredsAcceptRequestFormat"
-					}
-				},
-				"type": "object",
-				"description": "Get the payload for a specific method from a list of CredentialFormat interfaces and a method"
-			},
-			"AcceptCredentialRequestOptions": {
-				"properties": {
-					"credentialFormats": {
-						"$ref": "#/components/schemas/CredentialFormatPayload_CredentialFormats.acceptRequest_"
-					},
-					"autoAcceptCredential": {
-						"$ref": "#/components/schemas/AutoAcceptCredential"
-					},
-					"comment": {
-						"type": "string"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"DidExchangeState": {
-				"description": "Connection states as defined in RFC 0023.",
-				"enum": [
-					"start",
-					"invitation-sent",
-					"invitation-received",
-					"request-sent",
-					"request-received",
-					"response-sent",
-					"response-received",
-					"abandoned",
-					"completed"
-				],
-				"type": "string"
-			},
-			"DidExchangeRole": {
-				"enum": [
-					"requester",
-					"responder"
-				],
-				"type": "string"
-			},
-			"ConnectionType": {
-				"enum": [
-					"mediator"
-				],
-				"type": "string"
-			},
-			"DidCommConnectionRecord": {
-				"properties": {
-					"id": {
-						"$ref": "#/components/schemas/RecordId"
-					},
-					"createdAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"updatedAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"type": {
-						"type": "string"
-					},
-					"did": {
-						"$ref": "#/components/schemas/Did"
-					},
-					"theirDid": {
-						"$ref": "#/components/schemas/Did"
-					},
-					"theirLabel": {
-						"type": "string"
-					},
-					"state": {
-						"$ref": "#/components/schemas/DidExchangeState"
-					},
-					"role": {
-						"$ref": "#/components/schemas/DidExchangeRole"
-					},
-					"alias": {
-						"type": "string"
-					},
-					"autoAcceptConnection": {
-						"type": "boolean"
-					},
-					"threadId": {
-						"$ref": "#/components/schemas/ThreadId"
-					},
-					"imageUrl": {
-						"type": "string"
-					},
-					"mediatorId": {
-						"type": "string"
-					},
-					"errorMessage": {
-						"type": "string"
-					},
-					"protocol": {
-						"$ref": "#/components/schemas/HandshakeProtocol"
-					},
-					"outOfBandId": {
-						"type": "string"
-					},
-					"invitationDid": {
-						"$ref": "#/components/schemas/Did"
-					},
-					"connectionTypes": {
-						"items": {
-							"anyOf": [
-								{
-									"$ref": "#/components/schemas/ConnectionType"
-								},
-								{
-									"type": "string"
-								}
-							]
-						},
-						"type": "array"
-					},
-					"previousDids": {
-						"items": {
-							"$ref": "#/components/schemas/Did"
-						},
-						"type": "array"
-					},
-					"previousTheirDids": {
-						"items": {
-							"$ref": "#/components/schemas/Did"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"id",
-					"createdAt",
-					"type",
-					"state",
-					"role"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"BasicMessageRole": {
-				"enum": [
-					"sender",
-					"receiver"
-				],
-				"type": "string"
-			},
-			"DidCommBasicMessageRecord": {
-				"properties": {
-					"id": {
-						"$ref": "#/components/schemas/RecordId"
-					},
-					"createdAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"updatedAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"type": {
-						"type": "string"
-					},
-					"connectionId": {
-						"$ref": "#/components/schemas/RecordId"
-					},
-					"role": {
-						"$ref": "#/components/schemas/BasicMessageRole"
-					},
-					"content": {
-						"type": "string"
-					},
-					"sentTime": {
-						"type": "string"
-					},
-					"threadId": {
-						"$ref": "#/components/schemas/ThreadId"
-					},
-					"parentThreadId": {
-						"$ref": "#/components/schemas/ThreadId"
-					}
-				},
-				"required": [
-					"id",
-					"createdAt",
-					"type",
-					"connectionId",
-					"role",
-					"content",
-					"sentTime"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"DidCommBasicMessagesSendOptions": {
-				"properties": {
-					"connectionId": {
-						"$ref": "#/components/schemas/RecordId"
-					},
-					"content": {
-						"type": "string"
-					},
-					"parentThreadId": {
-						"$ref": "#/components/schemas/ThreadId"
-					}
-				},
-				"required": [
-					"connectionId",
-					"content"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"DidResolutionMetadata": {
-				"properties": {
-					"contentType": {
-						"type": "string"
-					},
-					"error": {
-						"anyOf": [
-							{
-								"type": "string"
-							},
-							{
-								"type": "string",
-								"enum": [
-									"invalidDid",
-									"notFound",
-									"representationNotSupported",
-									"unsupportedDidMethod"
-								]
-							}
-						]
-					},
-					"message": {
-						"type": "string"
-					},
-					"servedFromCache": {
-						"type": "boolean"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"JsonWebKey": {
-				"description": "Encapsulates a JSON web key type that includes only the public properties that\r\ncan be used in DID documents.\r\n\r\nThe private properties are intentionally omitted to discourage the use\r\n(and accidental disclosure) of private keys in DID documents.",
-				"properties": {
-					"alg": {
-						"type": "string"
-					},
-					"crv": {
-						"type": "string"
-					},
-					"e": {
-						"type": "string"
-					},
-					"ext": {
-						"type": "boolean"
-					},
-					"key_ops": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"kid": {
-						"type": "string"
-					},
-					"kty": {
-						"type": "string"
-					},
-					"n": {
-						"type": "string"
-					},
-					"use": {
-						"type": "string"
-					},
-					"x": {
-						"type": "string"
-					},
-					"y": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"kty"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"VerificationMethod": {
-				"description": "Represents the properties of a Verification Method listed in a DID document.\r\n\r\nThis data type includes public key representations that are no longer present in the spec but are still used by\r\nseveral DID methods / resolvers and kept for backward compatibility.",
-				"properties": {
-					"id": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"controller": {
-						"type": "string"
-					},
-					"publicKeyBase58": {
-						"type": "string"
-					},
-					"publicKeyBase64": {
-						"type": "string"
-					},
-					"publicKeyJwk": {
-						"$ref": "#/components/schemas/JsonWebKey"
-					},
-					"publicKeyHex": {
-						"type": "string"
-					},
-					"publicKeyMultibase": {
-						"type": "string"
-					},
-					"blockchainAccountId": {
-						"type": "string"
-					},
-					"ethereumAddress": {
-						"type": "string"
-					},
-					"conditionOr": {
-						"items": {
-							"$ref": "#/components/schemas/VerificationMethod"
-						},
-						"type": "array"
-					},
-					"conditionAnd": {
-						"items": {
-							"$ref": "#/components/schemas/VerificationMethod"
-						},
-						"type": "array"
-					},
-					"threshold": {
-						"type": "number",
-						"format": "double"
-					},
-					"conditionThreshold": {
-						"items": {
-							"$ref": "#/components/schemas/VerificationMethod"
-						},
-						"type": "array"
-					},
-					"conditionWeightedThreshold": {
-						"items": {
-							"$ref": "#/components/schemas/ConditionWeightedThreshold"
-						},
-						"type": "array"
-					},
-					"conditionDelegated": {
-						"type": "string"
-					},
-					"relationshipParent": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"relationshipChild": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"relationshipSibling": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"id",
-					"type",
-					"controller"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"ConditionWeightedThreshold": {
-				"properties": {
-					"condition": {
-						"$ref": "#/components/schemas/VerificationMethod"
-					},
-					"weight": {
-						"type": "number",
-						"format": "double"
-					}
-				},
-				"required": [
-					"condition",
-					"weight"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"ServiceEndpoint": {
-				"anyOf": [
-					{
-						"type": "string"
-					},
-					{
-						"$ref": "#/components/schemas/Record_string.any_"
-					}
-				],
-				"description": "Represents an endpoint of a Service entry in a DID document."
-			},
-			"Service": {
-				"description": "Represents a Service entry in a {@link https://www.w3.org/TR/did-core/#did-document-properties DID document}.",
-				"properties": {
-					"id": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"serviceEndpoint": {
-						"anyOf": [
-							{
-								"$ref": "#/components/schemas/ServiceEndpoint"
-							},
-							{
-								"items": {
-									"$ref": "#/components/schemas/ServiceEndpoint"
-								},
-								"type": "array"
-							}
-						]
-					}
-				},
-				"required": [
-					"id",
-					"type",
-					"serviceEndpoint"
-				],
-				"type": "object",
-				"additionalProperties": {}
-			},
-			"DIDDocument": {
-				"allOf": [
-					{
-						"properties": {
-							"publicKey": {
-								"items": {
-									"$ref": "#/components/schemas/VerificationMethod"
-								},
-								"type": "array",
-								"deprecated": true
-							},
-							"service": {
-								"items": {
-									"$ref": "#/components/schemas/Service"
-								},
-								"type": "array"
-							},
-							"verificationMethod": {
-								"items": {
-									"$ref": "#/components/schemas/VerificationMethod"
-								},
-								"type": "array"
-							},
-							"controller": {
-								"anyOf": [
-									{
-										"type": "string"
-									},
-									{
-										"items": {
-											"type": "string"
-										},
-										"type": "array"
-									}
-								]
-							},
-							"alsoKnownAs": {
-								"items": {
-									"type": "string"
-								},
-								"type": "array"
-							},
-							"id": {
-								"type": "string"
-							},
-							"@context": {
-								"anyOf": [
-									{
-										"type": "string"
-									},
-									{
-										"items": {
-											"type": "string"
-										},
-										"type": "array"
-									},
-									{
-										"type": "string",
-										"enum": [
-											"https://www.w3.org/ns/did/v1"
-										]
-									}
-								]
-							}
-						},
-						"required": [
-							"id"
-						],
-						"type": "object"
-					},
-					{
-						"properties": {
-							"authentication": {
-								"items": {
-									"anyOf": [
-										{
-											"type": "string"
-										},
-										{
-											"$ref": "#/components/schemas/VerificationMethod"
-										}
-									]
-								},
-								"type": "array"
-							},
-							"assertionMethod": {
-								"items": {
-									"anyOf": [
-										{
-											"type": "string"
-										},
-										{
-											"$ref": "#/components/schemas/VerificationMethod"
-										}
-									]
-								},
-								"type": "array"
-							},
-							"keyAgreement": {
-								"items": {
-									"anyOf": [
-										{
-											"type": "string"
-										},
-										{
-											"$ref": "#/components/schemas/VerificationMethod"
-										}
-									]
-								},
-								"type": "array"
-							},
-							"capabilityInvocation": {
-								"items": {
-									"anyOf": [
-										{
-											"type": "string"
-										},
-										{
-											"$ref": "#/components/schemas/VerificationMethod"
-										}
-									]
-								},
-								"type": "array"
-							},
-							"capabilityDelegation": {
-								"items": {
-									"anyOf": [
-										{
-											"type": "string"
-										},
-										{
-											"$ref": "#/components/schemas/VerificationMethod"
-										}
-									]
-								},
-								"type": "array"
-							}
-						},
-						"type": "object"
-					}
-				],
-				"description": "Represents a DID document."
-			},
-			"DidDocumentJson": {
-				"$ref": "#/components/schemas/DIDDocument",
-				"example": {
-					"@context": [
-						"https://w3id.org/did/v1",
-						"https://w3id.org/security/suites/ed25519-2018/v1",
-						"https://w3id.org/security/suites/x25519-2019/v1"
-					],
-					"id": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
-					"verificationMethod": [
-						{
-							"id": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK#z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
-							"type": "Ed25519VerificationKey2018",
-							"controller": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
-							"publicKeyBase58": "48GdbJyVULjHDaBNS6ct9oAGtckZUS5v8asrPzvZ7R1w"
-						}
-					],
-					"authentication": [
-						"did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK#z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
-					],
-					"assertionMethod": [
-						"did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK#z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
-					],
-					"keyAgreement": [
-						{
-							"id": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK#z6LSj72tK8brWgZja8NLRwPigth2T9QRiG1uH9oKZuKjdh9p",
-							"type": "X25519KeyAgreementKey2019",
-							"controller": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
-							"publicKeyBase58": "8RrinpnzRDqzUjzZuHsmNJUYbzsK1eqkQB5e5SgCvKP4"
-						}
-					],
-					"capabilityInvocation": [
-						"did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK#z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
-					],
-					"capabilityDelegation": [
-						"did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK#z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
-					]
-				}
-			},
-			"DIDDocumentMetadata": {
-				"description": "Represents metadata about the DID document resulting from a {@link Resolvable.resolve} operation.",
-				"properties": {
-					"created": {
-						"type": "string"
-					},
-					"updated": {
-						"type": "string"
-					},
-					"deactivated": {
-						"type": "boolean"
-					},
-					"versionId": {
-						"type": "string"
-					},
-					"nextUpdate": {
-						"type": "string"
-					},
-					"nextVersionId": {
-						"type": "string"
-					},
-					"equivalentId": {
-						"type": "string"
-					},
-					"canonicalId": {
-						"type": "string"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"DidDocumentMetadata": {
-				"$ref": "#/components/schemas/DIDDocumentMetadata"
-			},
-			"DidResolveSuccessResponse": {
-				"properties": {
-					"didResolutionMetadata": {
-						"$ref": "#/components/schemas/DidResolutionMetadata"
-					},
-					"didDocument": {
-						"$ref": "#/components/schemas/DidDocumentJson"
-					},
-					"didDocumentMetadata": {
-						"$ref": "#/components/schemas/DidDocumentMetadata"
-					}
-				},
-				"required": [
-					"didResolutionMetadata",
-					"didDocument",
-					"didDocumentMetadata"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"DidResolveFailedResponse": {
-				"properties": {
-					"didResolutionMetadata": {
-						"allOf": [
-							{
-								"$ref": "#/components/schemas/DidResolutionMetadata"
-							},
-							{
-								"properties": {
-									"error": {
-										"type": "string"
-									},
-									"message": {
-										"type": "string"
-									}
-								},
-								"required": [
-									"error",
-									"message"
-								],
-								"type": "object"
-							}
-						]
-					},
-					"didDocument": {
-						"allOf": [
-							{
-								"$ref": "#/components/schemas/DidDocumentJson"
-							}
-						],
-						"nullable": true
-					},
-					"didDocumentMetadata": {
-						"$ref": "#/components/schemas/DidDocumentMetadata"
-					}
-				},
-				"required": [
-					"didResolutionMetadata",
-					"didDocument",
-					"didDocumentMetadata"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"KeyType": {
-				"enum": [
-					"ed25519",
-					"bls12381g1g2",
-					"bls12381g1",
-					"bls12381g2",
-					"x25519",
-					"p256",
-					"p384",
-					"p521",
-					"k256"
-				],
-				"type": "string"
-			},
-			"PrivateKey": {
-				"properties": {
-					"keyType": {
-						"$ref": "#/components/schemas/KeyType"
-					},
-					"privateKeyBase58": {
-						"type": "string",
-						"description": "Base58 encoded private key"
-					}
-				},
-				"required": [
-					"keyType",
-					"privateKeyBase58"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"DidImportOptions": {
-				"properties": {
-					"did": {
-						"$ref": "#/components/schemas/Did"
-					},
-					"didDocument": {
-						"$ref": "#/components/schemas/DidDocumentJson"
-					},
-					"privateKeys": {
-						"items": {
-							"$ref": "#/components/schemas/PrivateKey"
-						},
-						"type": "array",
-						"description": "Private keys to import as part of the did document"
-					},
-					"overwrite": {
-						"type": "boolean",
-						"description": "Whether to overwrite the existing did document and private keys"
-					}
-				},
-				"required": [
-					"did"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AnyJsonObject": {
-				"description": "JSON object that can contain any key-value pairs",
-				"properties": {},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"DidCreateBaseResponse__state-finished--did-Did--didDocument-DidDocumentJson--secret_63_-AnyJsonObject__": {
-				"properties": {
-					"jobId": {
-						"type": "string"
-					},
-					"didRegistrationMetadata": {
-						"$ref": "#/components/schemas/AnyJsonObject"
-					},
-					"didDocumentMetadata": {
-						"$ref": "#/components/schemas/DidResolutionMetadata"
-					},
-					"didState": {
-						"properties": {
-							"secret": {
-								"$ref": "#/components/schemas/AnyJsonObject"
-							},
-							"didDocument": {
-								"$ref": "#/components/schemas/DidDocumentJson"
-							},
-							"did": {
-								"$ref": "#/components/schemas/Did"
-							},
-							"state": {
-								"type": "string",
-								"enum": [
-									"finished"
-								],
-								"nullable": false
-							}
-						},
-						"required": [
-							"didDocument",
-							"did",
-							"state"
-						],
-						"type": "object"
-					}
-				},
-				"required": [
-					"didRegistrationMetadata",
-					"didDocumentMetadata",
-					"didState"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"DidCreateFinishedResponse": {
-				"$ref": "#/components/schemas/DidCreateBaseResponse__state-finished--did-Did--didDocument-DidDocumentJson--secret_63_-AnyJsonObject__"
-			},
-			"DidCreateBaseResponse__state-failed--did_63_-Did--didDocument_63_-DidDocumentJson--secret_63_-AnyJsonObject--reason-string__": {
-				"properties": {
-					"jobId": {
-						"type": "string"
-					},
-					"didRegistrationMetadata": {
-						"$ref": "#/components/schemas/AnyJsonObject"
-					},
-					"didDocumentMetadata": {
-						"$ref": "#/components/schemas/DidResolutionMetadata"
-					},
-					"didState": {
-						"properties": {
-							"reason": {
-								"type": "string"
-							},
-							"secret": {
-								"$ref": "#/components/schemas/AnyJsonObject"
-							},
-							"didDocument": {
-								"$ref": "#/components/schemas/DidDocumentJson"
-							},
-							"did": {
-								"$ref": "#/components/schemas/Did"
-							},
-							"state": {
-								"type": "string",
-								"enum": [
-									"failed"
-								],
-								"nullable": false
-							}
-						},
-						"required": [
-							"reason",
-							"state"
-						],
-						"type": "object"
-					}
-				},
-				"required": [
-					"didRegistrationMetadata",
-					"didDocumentMetadata",
-					"didState"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"DidCreateFailedResponse": {
-				"$ref": "#/components/schemas/DidCreateBaseResponse__state-failed--did_63_-Did--didDocument_63_-DidDocumentJson--secret_63_-AnyJsonObject--reason-string__"
-			},
-			"DidCreateBaseResponse__state-action--action-string--did_63_-Did--didDocument_63_-DidDocumentJson--secret_63_-AnyJsonObject--_91_key-string_93__58_unknown__": {
-				"properties": {
-					"jobId": {
-						"type": "string"
-					},
-					"didRegistrationMetadata": {
-						"$ref": "#/components/schemas/AnyJsonObject"
-					},
-					"didDocumentMetadata": {
-						"$ref": "#/components/schemas/DidResolutionMetadata"
-					},
-					"didState": {
-						"properties": {
-							"secret": {
-								"$ref": "#/components/schemas/AnyJsonObject"
-							},
-							"didDocument": {
-								"$ref": "#/components/schemas/DidDocumentJson"
-							},
-							"did": {
-								"$ref": "#/components/schemas/Did"
-							},
-							"action": {
-								"type": "string"
-							},
-							"state": {
-								"type": "string",
-								"enum": [
-									"action"
-								],
-								"nullable": false
-							}
-						},
-						"additionalProperties": {},
-						"required": [
-							"action",
-							"state"
-						],
-						"type": "object"
-					}
-				},
-				"required": [
-					"didRegistrationMetadata",
-					"didDocumentMetadata",
-					"didState"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"DidCreateActionResponse": {
-				"$ref": "#/components/schemas/DidCreateBaseResponse__state-action--action-string--did_63_-Did--didDocument_63_-DidDocumentJson--secret_63_-AnyJsonObject--_91_key-string_93__58_unknown__"
-			},
-			"DidCreateBaseResponse__state-wait--did_63_-Did--didDocument_63_-DidDocumentJson--secret_63_-AnyJsonObject__": {
-				"properties": {
-					"jobId": {
-						"type": "string"
-					},
-					"didRegistrationMetadata": {
-						"$ref": "#/components/schemas/AnyJsonObject"
-					},
-					"didDocumentMetadata": {
-						"$ref": "#/components/schemas/DidResolutionMetadata"
-					},
-					"didState": {
-						"properties": {
-							"secret": {
-								"$ref": "#/components/schemas/AnyJsonObject"
-							},
-							"didDocument": {
-								"$ref": "#/components/schemas/DidDocumentJson"
-							},
-							"did": {
-								"$ref": "#/components/schemas/Did"
-							},
-							"state": {
-								"type": "string",
-								"enum": [
-									"wait"
-								],
-								"nullable": false
-							}
-						},
-						"required": [
-							"state"
-						],
-						"type": "object"
-					}
-				},
-				"required": [
-					"didRegistrationMetadata",
-					"didDocumentMetadata",
-					"didState"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"DidCreateWaitResponse": {
-				"$ref": "#/components/schemas/DidCreateBaseResponse__state-wait--did_63_-Did--didDocument_63_-DidDocumentJson--secret_63_-AnyJsonObject__"
-			},
-			"Pick_DidCreateBaseOptions.Exclude_keyofDidCreateBaseOptions.did-or-didDocument__": {
-				"properties": {
-					"method": {
-						"type": "string"
-					},
-					"options": {
-						"$ref": "#/components/schemas/AnyJsonObject"
-					},
-					"secret": {
-						"$ref": "#/components/schemas/AnyJsonObject"
-					}
-				},
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"KeyOrJwkDidCreateOptions": {
-				"properties": {
-					"method": {
-						"type": "string",
-						"enum": [
-							"key",
-							"jwk"
-						]
-					},
-					"options": {
-						"properties": {
-							"keyType": {
-								"$ref": "#/components/schemas/KeyType"
-							}
-						},
-						"required": [
-							"keyType"
-						],
-						"type": "object"
-					},
-					"secret": {
-						"properties": {
-							"privateKeyBase58": {
-								"type": "string"
-							},
-							"seedBase58": {
-								"type": "string"
-							}
-						},
-						"type": "object"
-					}
-				},
-				"required": [
-					"method",
-					"options"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"DidCreateBaseOptions": {
-				"properties": {
-					"method": {
-						"type": "string"
-					},
-					"did": {
-						"$ref": "#/components/schemas/Did"
-					},
-					"options": {
-						"$ref": "#/components/schemas/AnyJsonObject"
-					},
-					"secret": {
-						"$ref": "#/components/schemas/AnyJsonObject"
-					},
-					"didDocument": {
-						"$ref": "#/components/schemas/DidDocumentJson"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"DidCreateOptions": {
-				"anyOf": [
-					{
-						"$ref": "#/components/schemas/KeyOrJwkDidCreateOptions"
-					},
-					{
-						"$ref": "#/components/schemas/DidCreateBaseOptions"
-					}
-				]
-			},
-			"AnonCredsSchemaId": {
-				"type": "string"
-			},
-			"AnonCredsSchema": {
-				"properties": {
-					"issuerId": {
-						"type": "string"
-					},
-					"name": {
-						"type": "string"
-					},
-					"version": {
-						"type": "string"
-					},
-					"attrNames": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"issuerId",
-					"name",
-					"version",
-					"attrNames"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AnonCredsGetSchemaSuccessResponse": {
-				"properties": {
-					"schemaId": {
-						"$ref": "#/components/schemas/AnonCredsSchemaId"
-					},
-					"schema": {
-						"$ref": "#/components/schemas/AnonCredsSchema"
-					},
-					"resolutionMetadata": {
-						"$ref": "#/components/schemas/AnyJsonObject"
-					},
-					"schemaMetadata": {
-						"$ref": "#/components/schemas/AnyJsonObject"
-					}
-				},
-				"required": [
-					"schemaId",
-					"schema",
-					"resolutionMetadata",
-					"schemaMetadata"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Required_AnonCredsResolutionMetadata_": {
-				"properties": {
-					"error": {
-						"type": "string"
-					},
-					"message": {
-						"type": "string"
-					}
-				},
-				"additionalProperties": {},
-				"required": [
-					"error",
-					"message"
-				],
-				"type": "object",
-				"description": "Make all properties in T required"
-			},
-			"AnonCredsGetSchemaFailedResponse": {
-				"properties": {
-					"schemaId": {
-						"$ref": "#/components/schemas/AnonCredsSchemaId"
-					},
-					"schema": {
-						"$ref": "#/components/schemas/AnonCredsSchema"
-					},
-					"resolutionMetadata": {
-						"$ref": "#/components/schemas/Required_AnonCredsResolutionMetadata_"
-					},
-					"schemaMetadata": {
-						"$ref": "#/components/schemas/AnyJsonObject"
-					}
-				},
-				"required": [
-					"schemaId",
-					"resolutionMetadata",
-					"schemaMetadata"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"RegisterSchemaReturnStateFinished": {
-				"properties": {
-					"state": {
-						"type": "string",
-						"enum": [
-							"finished"
-						],
-						"nullable": false
-					},
-					"schema": {
-						"$ref": "#/components/schemas/AnonCredsSchema"
-					},
-					"schemaId": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"state",
-					"schema",
-					"schemaId"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AnonCredsRegisterSchemaSuccessResponse": {
-				"properties": {
-					"jobId": {
-						"type": "string"
-					},
-					"schemaState": {
-						"$ref": "#/components/schemas/RegisterSchemaReturnStateFinished"
-					},
-					"schemaMetadata": {
-						"$ref": "#/components/schemas/AnyJsonObject"
-					},
-					"registrationMetadata": {
-						"$ref": "#/components/schemas/AnyJsonObject"
-					}
-				},
-				"required": [
-					"schemaState",
-					"schemaMetadata",
-					"registrationMetadata"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"RegisterSchemaReturnStateFailed": {
-				"properties": {
-					"state": {
-						"type": "string",
-						"enum": [
-							"failed"
-						],
-						"nullable": false
-					},
-					"reason": {
-						"type": "string"
-					},
-					"schema": {
-						"$ref": "#/components/schemas/AnonCredsSchema"
-					},
-					"schemaId": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"state",
-					"reason"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AnonCredsRegisterSchemaFailedResponse": {
-				"properties": {
-					"jobId": {
-						"type": "string"
-					},
-					"schemaState": {
-						"$ref": "#/components/schemas/RegisterSchemaReturnStateFailed"
-					},
-					"schemaMetadata": {
-						"$ref": "#/components/schemas/AnyJsonObject"
-					},
-					"registrationMetadata": {
-						"$ref": "#/components/schemas/AnyJsonObject"
-					}
-				},
-				"required": [
-					"schemaState",
-					"schemaMetadata",
-					"registrationMetadata"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"RegisterSchemaReturnStateAction": {
-				"properties": {
-					"state": {
-						"type": "string",
-						"enum": [
-							"action"
-						],
-						"nullable": false
-					},
-					"action": {
-						"type": "string"
-					},
-					"schema": {
-						"$ref": "#/components/schemas/AnonCredsSchema"
-					},
-					"schemaId": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"state",
-					"action",
-					"schema",
-					"schemaId"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AnonCredsRegisterSchemaActionResponse": {
-				"properties": {
-					"jobId": {
-						"type": "string"
-					},
-					"schemaState": {
-						"$ref": "#/components/schemas/RegisterSchemaReturnStateAction"
-					},
-					"schemaMetadata": {
-						"$ref": "#/components/schemas/AnyJsonObject"
-					},
-					"registrationMetadata": {
-						"$ref": "#/components/schemas/AnyJsonObject"
-					}
-				},
-				"required": [
-					"schemaState",
-					"schemaMetadata",
-					"registrationMetadata"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"RegisterSchemaReturnStateWait": {
-				"properties": {
-					"state": {
-						"type": "string",
-						"enum": [
-							"wait"
-						],
-						"nullable": false
-					},
-					"schema": {
-						"$ref": "#/components/schemas/AnonCredsSchema"
-					},
-					"schemaId": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"state"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AnonCredsRegisterSchemaWaitResponse": {
-				"properties": {
-					"jobId": {
-						"type": "string"
-					},
-					"schemaState": {
-						"$ref": "#/components/schemas/RegisterSchemaReturnStateWait"
-					},
-					"schemaMetadata": {
-						"$ref": "#/components/schemas/AnyJsonObject"
-					},
-					"registrationMetadata": {
-						"$ref": "#/components/schemas/AnyJsonObject"
-					}
-				},
-				"required": [
-					"schemaState",
-					"schemaMetadata",
-					"registrationMetadata"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AnonCredsRegisterSchemaBody": {
-				"properties": {
-					"schema": {
-						"$ref": "#/components/schemas/AnonCredsSchema"
-					},
-					"options": {
-						"$ref": "#/components/schemas/AnyJsonObject"
-					}
-				},
-				"required": [
-					"schema"
-				],
-				"type": "object",
-				"additionalProperties": false,
-				"example": {
-					"schema": {
-						"issuerId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv",
-						"name": "schema-name",
-						"version": "1.0",
-						"attrNames": [
-							"age"
-						]
-					}
-				}
-			},
-			"AnonCredsCredentialDefinitionId": {
-				"type": "string"
-			},
-			"AnonCredsCredentialDefinition": {
-				"properties": {
-					"issuerId": {
-						"type": "string"
-					},
-					"schemaId": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string",
-						"enum": [
-							"CL"
-						],
-						"nullable": false
-					},
-					"tag": {
-						"type": "string"
-					},
-					"value": {
-						"properties": {
-							"revocation": {},
-							"primary": {
-								"$ref": "#/components/schemas/Record_string.unknown_"
-							}
-						},
-						"required": [
-							"primary"
-						],
-						"type": "object"
-					}
-				},
-				"required": [
-					"issuerId",
-					"schemaId",
-					"type",
-					"tag",
-					"value"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AnonCredsGetCredentialDefinitionSuccessResponse": {
-				"properties": {
-					"credentialDefinitionId": {
-						"$ref": "#/components/schemas/AnonCredsCredentialDefinitionId"
-					},
-					"credentialDefinition": {
-						"$ref": "#/components/schemas/AnonCredsCredentialDefinition"
-					},
-					"resolutionMetadata": {
-						"$ref": "#/components/schemas/AnyJsonObject"
-					},
-					"credentialDefinitionMetadata": {
-						"$ref": "#/components/schemas/AnyJsonObject"
-					}
-				},
-				"required": [
-					"credentialDefinitionId",
-					"credentialDefinition",
-					"resolutionMetadata",
-					"credentialDefinitionMetadata"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AnonCredsGetCredentialDefinitionFailedResponse": {
-				"properties": {
-					"credentialDefinitionId": {
-						"$ref": "#/components/schemas/AnonCredsCredentialDefinitionId"
-					},
-					"credentialDefinition": {
-						"$ref": "#/components/schemas/AnonCredsCredentialDefinition"
-					},
-					"resolutionMetadata": {
-						"$ref": "#/components/schemas/Required_AnonCredsResolutionMetadata_"
-					},
-					"credentialDefinitionMetadata": {
-						"$ref": "#/components/schemas/AnyJsonObject"
-					}
-				},
-				"required": [
-					"credentialDefinitionId",
-					"resolutionMetadata",
-					"credentialDefinitionMetadata"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"RegisterCredentialDefinitionReturnStateFinished": {
-				"properties": {
-					"state": {
-						"type": "string",
-						"enum": [
-							"finished"
-						],
-						"nullable": false
-					},
-					"credentialDefinition": {
-						"$ref": "#/components/schemas/AnonCredsCredentialDefinition"
-					},
-					"credentialDefinitionId": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"state",
-					"credentialDefinition",
-					"credentialDefinitionId"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AnonCredsRegisterCredentialDefinitionSuccessResponse": {
-				"properties": {
-					"jobId": {
-						"type": "string"
-					},
-					"credentialDefinitionState": {
-						"$ref": "#/components/schemas/RegisterCredentialDefinitionReturnStateFinished"
-					},
-					"credentialDefinitionMetadata": {
-						"$ref": "#/components/schemas/AnyJsonObject"
-					},
-					"registrationMetadata": {
-						"$ref": "#/components/schemas/AnyJsonObject"
-					}
-				},
-				"required": [
-					"credentialDefinitionState",
-					"credentialDefinitionMetadata",
-					"registrationMetadata"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"RegisterCredentialDefinitionReturnStateFailed": {
-				"properties": {
-					"state": {
-						"type": "string",
-						"enum": [
-							"failed"
-						],
-						"nullable": false
-					},
-					"reason": {
-						"type": "string"
-					},
-					"credentialDefinition": {
-						"$ref": "#/components/schemas/AnonCredsCredentialDefinition"
-					},
-					"credentialDefinitionId": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"state",
-					"reason"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AnonCredsRegisterCredentialDefinitionFailedResponse": {
-				"properties": {
-					"jobId": {
-						"type": "string"
-					},
-					"credentialDefinitionState": {
-						"$ref": "#/components/schemas/RegisterCredentialDefinitionReturnStateFailed"
-					},
-					"credentialDefinitionMetadata": {
-						"$ref": "#/components/schemas/AnyJsonObject"
-					},
-					"registrationMetadata": {
-						"$ref": "#/components/schemas/AnyJsonObject"
-					}
-				},
-				"required": [
-					"credentialDefinitionState",
-					"credentialDefinitionMetadata",
-					"registrationMetadata"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"RegisterCredentialDefinitionReturnStateAction": {
-				"properties": {
-					"state": {
-						"type": "string",
-						"enum": [
-							"action"
-						],
-						"nullable": false
-					},
-					"action": {
-						"type": "string"
-					},
-					"credentialDefinitionId": {
-						"type": "string"
-					},
-					"credentialDefinition": {
-						"$ref": "#/components/schemas/AnonCredsCredentialDefinition"
-					}
-				},
-				"required": [
-					"state",
-					"action",
-					"credentialDefinitionId",
-					"credentialDefinition"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AnonCredsRegisterCredentialDefinitionActionResponse": {
-				"properties": {
-					"jobId": {
-						"type": "string"
-					},
-					"credentialDefinitionState": {
-						"$ref": "#/components/schemas/RegisterCredentialDefinitionReturnStateAction"
-					},
-					"credentialDefinitionMetadata": {
-						"$ref": "#/components/schemas/AnyJsonObject"
-					},
-					"registrationMetadata": {
-						"$ref": "#/components/schemas/AnyJsonObject"
-					}
-				},
-				"required": [
-					"credentialDefinitionState",
-					"credentialDefinitionMetadata",
-					"registrationMetadata"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"RegisterCredentialDefinitionReturnStateWait": {
-				"properties": {
-					"state": {
-						"type": "string",
-						"enum": [
-							"wait"
-						],
-						"nullable": false
-					},
-					"credentialDefinition": {
-						"$ref": "#/components/schemas/AnonCredsCredentialDefinition"
-					},
-					"credentialDefinitionId": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"state"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AnonCredsRegisterCredentialDefinitionWaitResponse": {
-				"properties": {
-					"jobId": {
-						"type": "string"
-					},
-					"credentialDefinitionState": {
-						"$ref": "#/components/schemas/RegisterCredentialDefinitionReturnStateWait"
-					},
-					"credentialDefinitionMetadata": {
-						"$ref": "#/components/schemas/AnyJsonObject"
-					},
-					"registrationMetadata": {
-						"$ref": "#/components/schemas/AnyJsonObject"
-					}
-				},
-				"required": [
-					"credentialDefinitionState",
-					"credentialDefinitionMetadata",
-					"registrationMetadata"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AnonCredsRegisterCredentialDefinitionInput": {
-				"properties": {
-					"issuerId": {
-						"type": "string"
-					},
-					"schemaId": {
-						"type": "string"
-					},
-					"tag": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"issuerId",
-					"schemaId",
-					"tag"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AnonCredsRegisterCredentialDefinitionOptions": {
-				"properties": {
-					"supportRevocation": {
-						"type": "boolean"
-					}
-				},
-				"required": [
-					"supportRevocation"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AnonCredsRegisterCredentialDefinitionBody": {
-				"properties": {
-					"credentialDefinition": {
-						"$ref": "#/components/schemas/AnonCredsRegisterCredentialDefinitionInput"
-					},
-					"options": {
-						"$ref": "#/components/schemas/AnonCredsRegisterCredentialDefinitionOptions"
-					}
-				},
-				"required": [
-					"credentialDefinition",
-					"options"
-				],
-				"type": "object",
-				"additionalProperties": false,
-				"example": {
-					"credentialDefinition": {
-						"issuerId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv",
-						"schemaId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv/anoncreds/v0/SCHEMA/schema-name/1.0",
-						"tag": "definition"
-					},
-					"options": {
-						"supportRevocation": true
-					}
-				}
-			},
-			"DidCommMimeType": {
-				"enum": [
-					"application/ssi-agent-wire",
-					"application/didcomm-envelope-enc"
-				],
-				"type": "string"
-			},
-			"Pick_ReturnType_AgentConfig-at-toJSON_.Exclude_keyofReturnType_AgentConfig-at-toJSON_.walletConfig-or-logger-or-agentDependencies__": {
-				"properties": {
-					"label": {
-						"type": "string"
-					},
-					"connectionImageUrl": {
-						"type": "string"
-					},
-					"endpoints": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"didCommMimeType": {
-						"$ref": "#/components/schemas/DidCommMimeType"
-					},
-					"useDidKeyInProtocols": {
-						"type": "boolean"
-					},
-					"useDidSovPrefixWhereAllowed": {
-						"type": "boolean"
-					},
-					"autoUpdateStorageOnStartup": {
-						"type": "boolean"
-					},
-					"backupBeforeStorageUpdate": {
-						"type": "boolean"
-					}
-				},
-				"required": [
-					"label"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"ApiAgentConfig": {
-				"properties": {
-					"label": {
-						"type": "string"
-					},
-					"connectionImageUrl": {
-						"type": "string"
-					},
-					"endpoints": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"didCommMimeType": {
-						"$ref": "#/components/schemas/DidCommMimeType"
-					},
-					"useDidKeyInProtocols": {
-						"type": "boolean"
-					},
-					"useDidSovPrefixWhereAllowed": {
-						"type": "boolean"
-					},
-					"autoUpdateStorageOnStartup": {
-						"type": "boolean"
-					},
-					"backupBeforeStorageUpdate": {
-						"type": "boolean"
-					}
-				},
-				"required": [
-					"label"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AgentInfo": {
-				"properties": {
-					"config": {
-						"$ref": "#/components/schemas/ApiAgentConfig",
-						"description": "The config of the agent."
-					},
-					"isInitialized": {
-						"type": "boolean",
-						"description": "Whether the agent has been initialized."
-					}
-				},
-				"required": [
-					"config",
-					"isInitialized"
-				],
-				"type": "object",
-				"additionalProperties": false
-			}
-		},
-		"securitySchemes": {
-			"tenants": {
-				"type": "apiKey",
-				"name": "x-tenant-id",
-				"in": "header"
-			}
-		}
-	},
-	"info": {
-		"title": "Credo REST API",
-		"version": "0.9.5",
-		"description": "Rest API for using Credo over HTTP",
-		"license": {
-			"name": "Apache-2.0"
-		},
-		"contact": {}
-	},
-	"paths": {
-		"/tenants": {
-			"post": {
-				"operationId": "CreateTenant",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/TenantsRecord"
-								}
-							}
-						}
-					}
-				},
-				"description": "create new tenant",
-				"tags": [
-					"Tenants"
-				],
-				"security": [
-					{
-						"tenants": [
-							"admin"
-						]
-					}
-				],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/TenantsCreateOptions"
-							}
-						}
-					}
-				}
-			},
-			"get": {
-				"operationId": "GetTenantsByQuery",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"items": {
-										"$ref": "#/components/schemas/TenantsRecord"
-									},
-									"type": "array"
-								}
-							}
-						}
-					}
-				},
-				"description": "get tenants by query",
-				"tags": [
-					"Tenants"
-				],
-				"security": [
-					{
-						"tenants": [
-							"admin"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "query",
-						"name": "label",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"in": "query",
-						"name": "storageVersion",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/tenants/{tenantId}": {
-			"get": {
-				"operationId": "GetTenant",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/TenantsRecord"
-								}
-							}
-						}
-					}
-				},
-				"description": "get tenant by id",
-				"tags": [
-					"Tenants"
-				],
-				"security": [
-					{
-						"tenants": [
-							"admin"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "tenantId",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			},
-			"put": {
-				"operationId": "UpdateTenant",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/TenantsRecord"
-								}
-							}
-						}
-					}
-				},
-				"description": "update tenant by id.\n\nNOTE: this does not overwrite the entire tenant record, only the properties that are passed in the body.\nIf you want to unset an non-required value, you can pass `null`.",
-				"tags": [
-					"Tenants"
-				],
-				"security": [
-					{
-						"tenants": [
-							"admin"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "tenantId",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/TenantsUpdateOptions"
-							}
-						}
-					}
-				}
-			},
-			"delete": {
-				"operationId": "DeleteTenant",
-				"responses": {
-					"204": {
-						"description": "No content"
-					}
-				},
-				"description": "delete tenant by id",
-				"tags": [
-					"Tenants"
-				],
-				"security": [
-					{
-						"tenants": [
-							"admin"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "tenantId",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/openid4vc/verifiers": {
-			"post": {
-				"operationId": "CreateVerifier",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/OpenId4VcVerifierRecord"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"id": "a3327f09-1d48-48a5-89b1-6678a33c0539",
-											"createdAt": "2024-03-29T15:26:58.347Z",
-											"updatedAt": "2024-03-29T15:26:58.347Z",
-											"type": "OpenId4VcVerifierRecord",
-											"publicVerifierId": "0aa796ef-d79d-457f-a4b9-40b99e47fef2"
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Create a new OpenID4VC Verifier",
-				"tags": [
-					"OpenID4VC Verifiers"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/OpenId4VcVerifiersCreateOptions"
-							}
-						}
-					}
-				}
-			},
-			"get": {
-				"operationId": "GetVerifiersByQuery",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"items": {
-										"$ref": "#/components/schemas/OpenId4VcVerifierRecord"
-									},
-									"type": "array"
-								},
-								"examples": {
-									"Example 1": {
-										"value": [
-											{
-												"id": "a3327f09-1d48-48a5-89b1-6678a33c0539",
-												"createdAt": "2024-03-29T15:26:58.347Z",
-												"updatedAt": "2024-03-29T15:26:58.347Z",
-												"type": "OpenId4VcVerifierRecord",
-												"publicVerifierId": "0aa796ef-d79d-457f-a4b9-40b99e47fef2"
-											}
-										]
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Get OpenID4VC verifiers by query",
-				"tags": [
-					"OpenID4VC Verifiers"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "query",
-						"name": "publicVerifierId",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/openid4vc/verifiers/{verifierId}": {
-			"get": {
-				"operationId": "GetVerifier",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/OpenId4VcVerifierRecord"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"id": "a3327f09-1d48-48a5-89b1-6678a33c0539",
-											"createdAt": "2024-03-29T15:26:58.347Z",
-											"updatedAt": "2024-03-29T15:26:58.347Z",
-											"type": "OpenId4VcVerifierRecord",
-											"publicVerifierId": "0aa796ef-d79d-457f-a4b9-40b99e47fef2"
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Get an OpenID4VC verifier by id",
-				"tags": [
-					"OpenID4VC Verifiers"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "verifierId",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			},
-			"delete": {
-				"operationId": "DeleteVerifier",
-				"responses": {
-					"204": {
-						"description": "No content"
-					}
-				},
-				"description": "Delete an OpenID4VC verifier by id",
-				"tags": [
-					"OpenID4VC Verifiers"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "verifierId",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/openid4vc/verifiers/sessions/create-request": {
-			"post": {
-				"operationId": "CreateRequest",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/OpenId4VcVerificationSessionsCreateRequestResponse"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"verificationSession": {
-												"id": "9cde9070-23c9-4e51-b810-e929a0298cbb",
-												"createdAt": "2024-03-29T17:54:34.890Z",
-												"updatedAt": "2024-03-29T17:54:34.890Z",
-												"type": "OpenId4VcVerificationSessionRecord",
-												"publicVerifierId": "a868257d-7149-4d4d-a52c-78f3197ee538",
-												"authorizationRequestJwt": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa2dWaXdmc3RDTDFMOWk4dGdzZEFZRXU1QTYyVzVtQTlEY21TeWdWVlZMRnVVI3o2TWtnVml3ZnN0Q0wxTDlpOHRnc2RBWUV1NUE2Mlc1bUE5RGNtU3lnVlZWTEZ1VSIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE3MTE3MzgxNjEsImV4cCI6MTcxMTczODI4MSwicmVzcG9uc2VfdHlwZSI6ImlkX3Rva2VuIHZwX3Rva2VuIiwic2NvcGUiOiJvcGVuaWQiLCJjbGllbnRfaWQiOiJkaWQ6a2V5Ono2TWtnVml3ZnN0Q0wxTDlpOHRnc2RBWUV1NUE2Mlc1bUE5RGNtU3lnVlZWTEZ1VSIsInJlZGlyZWN0X3VyaSI6Imh0dHBzOi8vZDBjZS0yMTctMTIzLTE4LTI2Lm5ncm9rLWZyZWUuYXBwL3Npb3AvMWFiMzBjMGUtMWFkYi00ZjAxLTkwZTgtY2ZkNDI1YzBhMzExL2F1dGhvcml6ZSIsInJlc3BvbnNlX21vZGUiOiJwb3N0Iiwibm9uY2UiOiIxMDQwMzQ1NjY0MDI1NTEzODE3MzgyNjk4Iiwic3RhdGUiOiI0MzQ3NTE3MjgzNDM2ODc1NzYzODQ1MTAiLCJjbGllbnRfbWV0YWRhdGEiOnsiaWRfdG9rZW5fc2lnbmluZ19hbGdfdmFsdWVzX3N1cHBvcnRlZCI6WyJFZERTQSIsIkVTMjU2IiwiRVMyNTZLIl0sInJlc3BvbnNlX3R5cGVzX3N1cHBvcnRlZCI6WyJ2cF90b2tlbiIsImlkX3Rva2VuIl0sInN1YmplY3Rfc3ludGF4X3R5cGVzX3N1cHBvcnRlZCI6WyJkaWQ6d2ViIiwiZGlkOmtleSIsImRpZDpqd2siXSwidnBfZm9ybWF0cyI6eyJqd3RfdmMiOnsiYWxnIjpbIkVkRFNBIiwiRVMyNTYiLCJFUzI1NksiXX0sImp3dF92Y19qc29uIjp7ImFsZyI6WyJFZERTQSIsIkVTMjU2IiwiRVMyNTZLIl19LCJqd3RfdnAiOnsiYWxnIjpbIkVkRFNBIiwiRVMyNTYiLCJFUzI1NksiXX0sImxkcF92YyI6eyJwcm9vZl90eXBlIjpbIkVkMjU1MTlTaWduYXR1cmUyMDE4Il19LCJsZHBfdnAiOnsicHJvb2ZfdHlwZSI6WyJFZDI1NTE5U2lnbmF0dXJlMjAxOCJdfSwidmMrc2Qtand0Ijp7ImtiX2p3dF9hbGdfdmFsdWVzIjpbIkVkRFNBIiwiRVMyNTYiLCJFUzI1NksiXSwic2Rfand0X2FsZ192YWx1ZXMiOlsiRWREU0EiLCJFUzI1NiIsIkVTMjU2SyJdfX0sImNsaWVudF9pZCI6ImRpZDprZXk6ejZNa2dWaXdmc3RDTDFMOWk4dGdzZEFZRXU1QTYyVzVtQTlEY21TeWdWVlZMRnVVIn0sInByZXNlbnRhdGlvbl9kZWZpbml0aW9uIjp7ImlkIjoiNzM3OTdiMGMtZGFlNi00NmE3LTk3MDAtNzg1MDg1NWZlZTIyIiwibmFtZSI6IkV4YW1wbGUgUHJlc2VudGF0aW9uIERlZmluaXRpb24iLCJpbnB1dF9kZXNjcmlwdG9ycyI6W3siaWQiOiI2NDEyNTc0Mi04YjZjLTQyMmUtODJjZC0xYmViNTEyM2VlOGYiLCJjb25zdHJhaW50cyI6eyJsaW1pdF9kaXNjbG9zdXJlIjoicmVxdWlyZWQiLCJmaWVsZHMiOlt7InBhdGgiOlsiJC5hZ2Uub3Zlcl8xOCJdLCJmaWx0ZXIiOnsidHlwZSI6ImJvb2xlYW4ifX1dfSwibmFtZSI6IlJlcXVlc3RlZCBTZCBKd3QgRXhhbXBsZSBDcmVkZW50aWFsIiwicHVycG9zZSI6IlRvIHByb3ZpZGUgYW4gZXhhbXBsZSBvZiByZXF1ZXN0aW5nIGEgY3JlZGVudGlhbCJ9XX0sIm5iZiI6MTcxMTczODE2MSwianRpIjoiNThlNTA2MzgtOGU0ZS00NTQ5LWFmNDktMzQzNDI4N2IyODJlIiwiaXNzIjoiZGlkOmtleTp6Nk1rZ1Zpd2ZzdENMMUw5aTh0Z3NkQVlFdTVBNjJXNW1BOURjbVN5Z1ZWVkxGdVUiLCJzdWIiOiJkaWQ6a2V5Ono2TWtnVml3ZnN0Q0wxTDlpOHRnc2RBWUV1NUE2Mlc1bUE5RGNtU3lnVlZWTEZ1VSJ9.zAndpciC3rYi6tmItYi8P9uGqkId_3TNEgJHeFeBA1fWgJ4aY8Y2a5RmeGHl4-fXMV8Ff1-tpR86z-6v7pkvDQ",
-												"authorizationRequestUri": "https://d0ce-217-123-18-26.ngrok-free.app/siop/1ab30c0e-1adb-4f01-90e8-cfd425c0a311/authorization-requests/365d0d2f-e62b-4596-92cd-8c4baa7047d6",
-												"state": "RequestUriRetrieved"
-											},
-											"authorizationRequest": "openid://?request_uri=https%3A%2F%2Fexample.com%2Fsiop%2F6b293c23-d55a-4c6a-8c6a-877d69a70b4d%2Fauthorization-requests%2F6e7dce29-9d6a-4a13-a820-6a19b2ea9945"
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Create an OpenID4VC verification session by creating a authorization request",
-				"tags": [
-					"OpenID4VC Verification Sessions"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/OpenId4VcVerificationSessionsCreateRequestOptions"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/openid4vc/verifiers/sessions/{verificationSessionId}/verified-authorization-response": {
-			"get": {
-				"operationId": "GetVerifiedAuthorizationResponse",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/OpenId4VcVerificationSessionsGetVerifiedAuthorizationResponseResponse"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"idToken": {
-												"payload": {
-													"iat": 1711678207,
-													"exp": 1711744207,
-													"iss": "did:jwk:eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6InRZSkY5a0NCeXpJT1RWc1FOclhrRTlQZW92eEJrcUNuejBQN3Q5Y2poblUiLCJ5IjoiZnlIckh3U21PSGlfa2dDdGM2RWF4ckpZQ2R1WWRQbm5VTGJ5RVBPTGpabyJ9",
-													"aud": "did:key:z6MkgViwfstCL1L9i8tgsdAYEu5A62W5mA9DcmSygVVVLFuU",
-													"sub": "did:jwk:eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6InRZSkY5a0NCeXpJT1RWc1FOclhrRTlQZW92eEJrcUNuejBQN3Q5Y2poblUiLCJ5IjoiZnlIckh3U21PSGlfa2dDdGM2RWF4ckpZQ2R1WWRQbm5VTGJ5RVBPTGpabyJ9",
-													"nonce": "1040345664025513817382698",
-													"state": "434751728343687576384510"
-												}
-											},
-											"presentationExchange": {
-												"definition": {
-													"id": "73797b0c-dae6-46a7-9700-7850855fee22",
-													"name": "Example Presentation Definition",
-													"input_descriptors": [
-														{
-															"id": "64125742-8b6c-422e-82cd-1beb5123ee8f",
-															"constraints": {
-																"limit_disclosure": "required",
-																"fields": [
-																	{
-																		"path": [
-																			"$.age.over_18"
-																		],
-																		"filter": {
-																			"type": "boolean"
-																		}
-																	}
-																]
-															},
-															"name": "Requested Sd Jwt Example Credential",
-															"purpose": "To provide an example of requesting a credential"
-														}
-													]
-												},
-												"presentations": [
-													{
-														"format": "vc+sd-jwt",
-														"encoded": "eyJhbGciOiJFZERTQSIsInR5cCI6InZjK3NkLWp3dCIsImtpZCI6...",
-														"vcPayload": {
-															"first_name": "John",
-															"last_name": "Doe",
-															"age": {
-																"over_18": true
-															},
-															"vct": "https://example.com/vct#ExampleCredential",
-															"cnf": {
-																"kid": "did:jwk:eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6InRZSkY5a0NCeXpJT1RWc1FOclhrRTlQZW92eEJrcUNuejBQN3Q5Y2poblUiLCJ5IjoiZnlIckh3U21PSGlfa2dDdGM2RWF4ckpZQ2R1WWRQbm5VTGJ5RVBPTGpabyJ9#0"
-															},
-															"iss": "did:key:z6MkgViwfstCL1L9i8tgsdAYEu5A62W5mA9DcmSygVVVLFuU",
-															"iat": 1711737824
-														},
-														"signedPayload": {
-															"first_name": "John",
-															"last_name": "Doe",
-															"age": {
-																"_sd": [
-																	"7-KKV_C6uNhINhW1_6zdv9pHGeoSErL0kXQLRLGRkOs",
-																	"J-HR5dUgq0__vzlSknqLhZIgyfdqoFGz1IiWiUUjHy8",
-																	"Y5fMNOwiZgzQFD3XtjowpRYEr0Rw6YU7ZwDimGV3b60"
-																]
-															},
-															"vct": "https://example.com/vct#ExampleCredential",
-															"cnf": {
-																"kid": "did:jwk:eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6InRZSkY5a0NCeXpJT1RWc1FOclhrRTlQZW92eEJrcUNuejBQN3Q5Y2poblUiLCJ5IjoiZnlIckh3U21PSGlfa2dDdGM2RWF4ckpZQ2R1WWRQbm5VTGJ5RVBPTGpabyJ9#0"
-															},
-															"iss": "did:key:z6MkgViwfstCL1L9i8tgsdAYEu5A62W5mA9DcmSygVVVLFuU",
-															"iat": 1711737824,
-															"_sd_alg": "sha-256"
-														},
-														"header": {
-															"alg": "EdDSA",
-															"typ": "vc+sd-jwt",
-															"kid": "#z6MkgViwfstCL1L9i8tgsdAYEu5A62W5mA9DcmSygVVVLFuU"
-														}
-													}
-												],
-												"submission": {
-													"id": "tmCha4zQKAZF-aBTCT8W3",
-													"definition_id": "73797b0c-dae6-46a7-9700-7850855fee22",
-													"descriptor_map": [
-														{
-															"id": "64125742-8b6c-422e-82cd-1beb5123ee8f",
-															"format": "vc+sd-jwt",
-															"path": "$"
-														}
-													]
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Get the verified authorization response data for a OpenID4VC verification session.\n\nThis endpoint can only be called for verification sessions where the state is `ResponseVerified`.",
-				"tags": [
-					"OpenID4VC Verification Sessions"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "verificationSessionId",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/openid4vc/verifiers/sessions": {
-			"get": {
-				"operationId": "GetVerificationSessionsByQuery",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"items": {
-										"$ref": "#/components/schemas/OpenId4VcVerificationSessionRecord"
-									},
-									"type": "array"
-								},
-								"examples": {
-									"Example 1": {
-										"value": [
-											{
-												"id": "9cde9070-23c9-4e51-b810-e929a0298cbb",
-												"createdAt": "2024-03-29T17:54:34.890Z",
-												"updatedAt": "2024-03-29T17:54:34.890Z",
-												"type": "OpenId4VcVerificationSessionRecord",
-												"publicVerifierId": "a868257d-7149-4d4d-a52c-78f3197ee538",
-												"authorizationRequestJwt": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa2dWaXdmc3RDTDFMOWk4dGdzZEFZRXU1QTYyVzVtQTlEY21TeWdWVlZMRnVVI3o2TWtnVml3ZnN0Q0wxTDlpOHRnc2RBWUV1NUE2Mlc1bUE5RGNtU3lnVlZWTEZ1VSIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE3MTE3MzgxNjEsImV4cCI6MTcxMTczODI4MSwicmVzcG9uc2VfdHlwZSI6ImlkX3Rva2VuIHZwX3Rva2VuIiwic2NvcGUiOiJvcGVuaWQiLCJjbGllbnRfaWQiOiJkaWQ6a2V5Ono2TWtnVml3ZnN0Q0wxTDlpOHRnc2RBWUV1NUE2Mlc1bUE5RGNtU3lnVlZWTEZ1VSIsInJlZGlyZWN0X3VyaSI6Imh0dHBzOi8vZDBjZS0yMTctMTIzLTE4LTI2Lm5ncm9rLWZyZWUuYXBwL3Npb3AvMWFiMzBjMGUtMWFkYi00ZjAxLTkwZTgtY2ZkNDI1YzBhMzExL2F1dGhvcml6ZSIsInJlc3BvbnNlX21vZGUiOiJwb3N0Iiwibm9uY2UiOiIxMDQwMzQ1NjY0MDI1NTEzODE3MzgyNjk4Iiwic3RhdGUiOiI0MzQ3NTE3MjgzNDM2ODc1NzYzODQ1MTAiLCJjbGllbnRfbWV0YWRhdGEiOnsiaWRfdG9rZW5fc2lnbmluZ19hbGdfdmFsdWVzX3N1cHBvcnRlZCI6WyJFZERTQSIsIkVTMjU2IiwiRVMyNTZLIl0sInJlc3BvbnNlX3R5cGVzX3N1cHBvcnRlZCI6WyJ2cF90b2tlbiIsImlkX3Rva2VuIl0sInN1YmplY3Rfc3ludGF4X3R5cGVzX3N1cHBvcnRlZCI6WyJkaWQ6d2ViIiwiZGlkOmtleSIsImRpZDpqd2siXSwidnBfZm9ybWF0cyI6eyJqd3RfdmMiOnsiYWxnIjpbIkVkRFNBIiwiRVMyNTYiLCJFUzI1NksiXX0sImp3dF92Y19qc29uIjp7ImFsZyI6WyJFZERTQSIsIkVTMjU2IiwiRVMyNTZLIl19LCJqd3RfdnAiOnsiYWxnIjpbIkVkRFNBIiwiRVMyNTYiLCJFUzI1NksiXX0sImxkcF92YyI6eyJwcm9vZl90eXBlIjpbIkVkMjU1MTlTaWduYXR1cmUyMDE4Il19LCJsZHBfdnAiOnsicHJvb2ZfdHlwZSI6WyJFZDI1NTE5U2lnbmF0dXJlMjAxOCJdfSwidmMrc2Qtand0Ijp7ImtiX2p3dF9hbGdfdmFsdWVzIjpbIkVkRFNBIiwiRVMyNTYiLCJFUzI1NksiXSwic2Rfand0X2FsZ192YWx1ZXMiOlsiRWREU0EiLCJFUzI1NiIsIkVTMjU2SyJdfX0sImNsaWVudF9pZCI6ImRpZDprZXk6ejZNa2dWaXdmc3RDTDFMOWk4dGdzZEFZRXU1QTYyVzVtQTlEY21TeWdWVlZMRnVVIn0sInByZXNlbnRhdGlvbl9kZWZpbml0aW9uIjp7ImlkIjoiNzM3OTdiMGMtZGFlNi00NmE3LTk3MDAtNzg1MDg1NWZlZTIyIiwibmFtZSI6IkV4YW1wbGUgUHJlc2VudGF0aW9uIERlZmluaXRpb24iLCJpbnB1dF9kZXNjcmlwdG9ycyI6W3siaWQiOiI2NDEyNTc0Mi04YjZjLTQyMmUtODJjZC0xYmViNTEyM2VlOGYiLCJjb25zdHJhaW50cyI6eyJsaW1pdF9kaXNjbG9zdXJlIjoicmVxdWlyZWQiLCJmaWVsZHMiOlt7InBhdGgiOlsiJC5hZ2Uub3Zlcl8xOCJdLCJmaWx0ZXIiOnsidHlwZSI6ImJvb2xlYW4ifX1dfSwibmFtZSI6IlJlcXVlc3RlZCBTZCBKd3QgRXhhbXBsZSBDcmVkZW50aWFsIiwicHVycG9zZSI6IlRvIHByb3ZpZGUgYW4gZXhhbXBsZSBvZiByZXF1ZXN0aW5nIGEgY3JlZGVudGlhbCJ9XX0sIm5iZiI6MTcxMTczODE2MSwianRpIjoiNThlNTA2MzgtOGU0ZS00NTQ5LWFmNDktMzQzNDI4N2IyODJlIiwiaXNzIjoiZGlkOmtleTp6Nk1rZ1Zpd2ZzdENMMUw5aTh0Z3NkQVlFdTVBNjJXNW1BOURjbVN5Z1ZWVkxGdVUiLCJzdWIiOiJkaWQ6a2V5Ono2TWtnVml3ZnN0Q0wxTDlpOHRnc2RBWUV1NUE2Mlc1bUE5RGNtU3lnVlZWTEZ1VSJ9.zAndpciC3rYi6tmItYi8P9uGqkId_3TNEgJHeFeBA1fWgJ4aY8Y2a5RmeGHl4-fXMV8Ff1-tpR86z-6v7pkvDQ",
-												"authorizationRequestUri": "https://d0ce-217-123-18-26.ngrok-free.app/siop/1ab30c0e-1adb-4f01-90e8-cfd425c0a311/authorization-requests/365d0d2f-e62b-4596-92cd-8c4baa7047d6",
-												"state": "RequestUriRetrieved"
-											}
-										]
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Find all OpenID4VC verification sessions by query",
-				"tags": [
-					"OpenID4VC Verification Sessions"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "query",
-						"name": "nonce",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"in": "query",
-						"name": "publicVerifierId",
-						"required": false,
-						"schema": {
-							"$ref": "#/components/schemas/PublicIssuerId"
-						}
-					},
-					{
-						"in": "query",
-						"name": "payloadState",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"in": "query",
-						"name": "state",
-						"required": false,
-						"schema": {
-							"$ref": "#/components/schemas/OpenId4VcVerificationSessionState"
-						}
-					},
-					{
-						"in": "query",
-						"name": "authorizationRequestUri",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/openid4vc/verifiers/sessions/{verificationSessionId}": {
-			"get": {
-				"operationId": "GetVerificationSession",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/OpenId4VcVerificationSessionRecord"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"id": "9cde9070-23c9-4e51-b810-e929a0298cbb",
-											"createdAt": "2024-03-29T17:54:34.890Z",
-											"updatedAt": "2024-03-29T17:54:34.890Z",
-											"type": "OpenId4VcVerificationSessionRecord",
-											"publicVerifierId": "a868257d-7149-4d4d-a52c-78f3197ee538",
-											"authorizationRequestJwt": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa2dWaXdmc3RDTDFMOWk4dGdzZEFZRXU1QTYyVzVtQTlEY21TeWdWVlZMRnVVI3o2TWtnVml3ZnN0Q0wxTDlpOHRnc2RBWUV1NUE2Mlc1bUE5RGNtU3lnVlZWTEZ1VSIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE3MTE3MzgxNjEsImV4cCI6MTcxMTczODI4MSwicmVzcG9uc2VfdHlwZSI6ImlkX3Rva2VuIHZwX3Rva2VuIiwic2NvcGUiOiJvcGVuaWQiLCJjbGllbnRfaWQiOiJkaWQ6a2V5Ono2TWtnVml3ZnN0Q0wxTDlpOHRnc2RBWUV1NUE2Mlc1bUE5RGNtU3lnVlZWTEZ1VSIsInJlZGlyZWN0X3VyaSI6Imh0dHBzOi8vZDBjZS0yMTctMTIzLTE4LTI2Lm5ncm9rLWZyZWUuYXBwL3Npb3AvMWFiMzBjMGUtMWFkYi00ZjAxLTkwZTgtY2ZkNDI1YzBhMzExL2F1dGhvcml6ZSIsInJlc3BvbnNlX21vZGUiOiJwb3N0Iiwibm9uY2UiOiIxMDQwMzQ1NjY0MDI1NTEzODE3MzgyNjk4Iiwic3RhdGUiOiI0MzQ3NTE3MjgzNDM2ODc1NzYzODQ1MTAiLCJjbGllbnRfbWV0YWRhdGEiOnsiaWRfdG9rZW5fc2lnbmluZ19hbGdfdmFsdWVzX3N1cHBvcnRlZCI6WyJFZERTQSIsIkVTMjU2IiwiRVMyNTZLIl0sInJlc3BvbnNlX3R5cGVzX3N1cHBvcnRlZCI6WyJ2cF90b2tlbiIsImlkX3Rva2VuIl0sInN1YmplY3Rfc3ludGF4X3R5cGVzX3N1cHBvcnRlZCI6WyJkaWQ6d2ViIiwiZGlkOmtleSIsImRpZDpqd2siXSwidnBfZm9ybWF0cyI6eyJqd3RfdmMiOnsiYWxnIjpbIkVkRFNBIiwiRVMyNTYiLCJFUzI1NksiXX0sImp3dF92Y19qc29uIjp7ImFsZyI6WyJFZERTQSIsIkVTMjU2IiwiRVMyNTZLIl19LCJqd3RfdnAiOnsiYWxnIjpbIkVkRFNBIiwiRVMyNTYiLCJFUzI1NksiXX0sImxkcF92YyI6eyJwcm9vZl90eXBlIjpbIkVkMjU1MTlTaWduYXR1cmUyMDE4Il19LCJsZHBfdnAiOnsicHJvb2ZfdHlwZSI6WyJFZDI1NTE5U2lnbmF0dXJlMjAxOCJdfSwidmMrc2Qtand0Ijp7ImtiX2p3dF9hbGdfdmFsdWVzIjpbIkVkRFNBIiwiRVMyNTYiLCJFUzI1NksiXSwic2Rfand0X2FsZ192YWx1ZXMiOlsiRWREU0EiLCJFUzI1NiIsIkVTMjU2SyJdfX0sImNsaWVudF9pZCI6ImRpZDprZXk6ejZNa2dWaXdmc3RDTDFMOWk4dGdzZEFZRXU1QTYyVzVtQTlEY21TeWdWVlZMRnVVIn0sInByZXNlbnRhdGlvbl9kZWZpbml0aW9uIjp7ImlkIjoiNzM3OTdiMGMtZGFlNi00NmE3LTk3MDAtNzg1MDg1NWZlZTIyIiwibmFtZSI6IkV4YW1wbGUgUHJlc2VudGF0aW9uIERlZmluaXRpb24iLCJpbnB1dF9kZXNjcmlwdG9ycyI6W3siaWQiOiI2NDEyNTc0Mi04YjZjLTQyMmUtODJjZC0xYmViNTEyM2VlOGYiLCJjb25zdHJhaW50cyI6eyJsaW1pdF9kaXNjbG9zdXJlIjoicmVxdWlyZWQiLCJmaWVsZHMiOlt7InBhdGgiOlsiJC5hZ2Uub3Zlcl8xOCJdLCJmaWx0ZXIiOnsidHlwZSI6ImJvb2xlYW4ifX1dfSwibmFtZSI6IlJlcXVlc3RlZCBTZCBKd3QgRXhhbXBsZSBDcmVkZW50aWFsIiwicHVycG9zZSI6IlRvIHByb3ZpZGUgYW4gZXhhbXBsZSBvZiByZXF1ZXN0aW5nIGEgY3JlZGVudGlhbCJ9XX0sIm5iZiI6MTcxMTczODE2MSwianRpIjoiNThlNTA2MzgtOGU0ZS00NTQ5LWFmNDktMzQzNDI4N2IyODJlIiwiaXNzIjoiZGlkOmtleTp6Nk1rZ1Zpd2ZzdENMMUw5aTh0Z3NkQVlFdTVBNjJXNW1BOURjbVN5Z1ZWVkxGdVUiLCJzdWIiOiJkaWQ6a2V5Ono2TWtnVml3ZnN0Q0wxTDlpOHRnc2RBWUV1NUE2Mlc1bUE5RGNtU3lnVlZWTEZ1VSJ9.zAndpciC3rYi6tmItYi8P9uGqkId_3TNEgJHeFeBA1fWgJ4aY8Y2a5RmeGHl4-fXMV8Ff1-tpR86z-6v7pkvDQ",
-											"authorizationRequestUri": "https://d0ce-217-123-18-26.ngrok-free.app/siop/1ab30c0e-1adb-4f01-90e8-cfd425c0a311/authorization-requests/365d0d2f-e62b-4596-92cd-8c4baa7047d6",
-											"state": "RequestUriRetrieved"
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Get an OpenID4VC verification session by verification session id",
-				"tags": [
-					"OpenID4VC Verification Sessions"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "verificationSessionId",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			},
-			"delete": {
-				"operationId": "DeleteVerificationSession",
-				"responses": {
-					"204": {
-						"description": "No content"
-					}
-				},
-				"description": "Delete an OpenID4VC verification session by id",
-				"tags": [
-					"OpenID4VC Verification Sessions"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "verificationSessionId",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/openid4vc/issuers": {
-			"post": {
-				"operationId": "CreateIssuer",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/OpenId4VcIssuerRecord"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"id": "65dff314-b7c8-4617-952e-a82864fecec5",
-											"createdAt": "2024-03-29T15:26:58.347Z",
-											"updatedAt": "2024-03-29T15:26:58.347Z",
-											"type": "OpenId4VcIssuerRecord",
-											"publicIssuerId": "129ea46f-92bc-4d44-8433-ac153b7da2e6",
-											"accessTokenPublicKeyFingerprint": "z6MkrSAZxmNERyktTeT2ich4Ntu3TPc5RdcB4sCsEbZa4vzh",
-											"credentialsSupported": [
-												{
-													"format": "vc+sd-jwt",
-													"id": "ExampleCredentialSdJwtVc",
-													"vct": "https://example.com/vct#ExampleCredential",
-													"cryptographic_binding_methods_supported": [
-														"did:key",
-														"did:jwk"
-													],
-													"cryptographic_suites_supported": [
-														"ES256",
-														"Ed25519"
-													],
-													"display": [
-														{
-															"name": "Example SD JWT Credential",
-															"description": "This is an example SD-JWT credential",
-															"background_color": "#ffffff",
-															"background_image": {
-																"url": "https://example.com/background.png",
-																"alt_text": "Example Credential Background"
-															},
-															"text_color": "#000000",
-															"locale": "en-US",
-															"logo": {
-																"url": "https://example.com/logo.png",
-																"alt_text": "Example Credential Logo"
-															}
-														}
-													]
-												},
-												{
-													"format": "jwt_vc_json",
-													"id": "ExampleCredentialJwtVc",
-													"types": [
-														"VerifiableCredential",
-														"ExampleCredential"
-													],
-													"cryptographic_binding_methods_supported": [
-														"did:key",
-														"did:jwk"
-													],
-													"cryptographic_suites_supported": [
-														"ES256",
-														"Ed25519"
-													],
-													"display": [
-														{
-															"name": "Example SD JWT Credential",
-															"description": "This is an example SD-JWT credential",
-															"background_color": "#ffffff",
-															"background_image": {
-																"url": "https://example.com/background.png",
-																"alt_text": "Example Credential Background"
-															},
-															"text_color": "#000000",
-															"locale": "en-US",
-															"logo": {
-																"url": "https://example.com/logo.png",
-																"alt_text": "Example Credential Logo"
-															}
-														}
-													]
-												}
-											],
-											"display": [
-												{
-													"background_color": "#ffffff",
-													"description": "This is an example issuer",
-													"name": "Example Issuer",
-													"locale": "en-US",
-													"logo": {
-														"alt_text": "Example Issuer Logo",
-														"url": "https://example.com/logo.png"
-													},
-													"text_color": "#000000"
-												}
-											]
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Create a new OpenID4VCI Issuer",
-				"tags": [
-					"OpenID4VC Issuers"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/OpenId4VcIssuersCreateOptions"
-							}
-						}
-					}
-				}
-			},
-			"get": {
-				"operationId": "GetIssuersByQuery",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"items": {
-										"$ref": "#/components/schemas/OpenId4VcIssuerRecord"
-									},
-									"type": "array"
-								},
-								"examples": {
-									"Example 1": {
-										"value": [
-											{
-												"id": "65dff314-b7c8-4617-952e-a82864fecec5",
-												"createdAt": "2024-03-29T15:26:58.347Z",
-												"updatedAt": "2024-03-29T15:26:58.347Z",
-												"type": "OpenId4VcIssuerRecord",
-												"publicIssuerId": "129ea46f-92bc-4d44-8433-ac153b7da2e6",
-												"accessTokenPublicKeyFingerprint": "z6MkrSAZxmNERyktTeT2ich4Ntu3TPc5RdcB4sCsEbZa4vzh",
-												"credentialsSupported": [
-													{
-														"format": "vc+sd-jwt",
-														"id": "ExampleCredentialSdJwtVc",
-														"vct": "https://example.com/vct#ExampleCredential",
-														"cryptographic_binding_methods_supported": [
-															"did:key",
-															"did:jwk"
-														],
-														"cryptographic_suites_supported": [
-															"ES256",
-															"Ed25519"
-														],
-														"display": [
-															{
-																"name": "Example SD JWT Credential",
-																"description": "This is an example SD-JWT credential",
-																"background_color": "#ffffff",
-																"background_image": {
-																	"url": "https://example.com/background.png",
-																	"alt_text": "Example Credential Background"
-																},
-																"text_color": "#000000",
-																"locale": "en-US",
-																"logo": {
-																	"url": "https://example.com/logo.png",
-																	"alt_text": "Example Credential Logo"
-																}
-															}
-														]
-													},
-													{
-														"format": "jwt_vc_json",
-														"id": "ExampleCredentialJwtVc",
-														"types": [
-															"VerifiableCredential",
-															"ExampleCredential"
-														],
-														"cryptographic_binding_methods_supported": [
-															"did:key",
-															"did:jwk"
-														],
-														"cryptographic_suites_supported": [
-															"ES256",
-															"Ed25519"
-														],
-														"display": [
-															{
-																"name": "Example SD JWT Credential",
-																"description": "This is an example SD-JWT credential",
-																"background_color": "#ffffff",
-																"background_image": {
-																	"url": "https://example.com/background.png",
-																	"alt_text": "Example Credential Background"
-																},
-																"text_color": "#000000",
-																"locale": "en-US",
-																"logo": {
-																	"url": "https://example.com/logo.png",
-																	"alt_text": "Example Credential Logo"
-																}
-															}
-														]
-													}
-												],
-												"display": [
-													{
-														"background_color": "#ffffff",
-														"description": "This is an example issuer",
-														"name": "Example Issuer",
-														"locale": "en-US",
-														"logo": {
-															"alt_text": "Example Issuer Logo",
-															"url": "https://example.com/logo.png"
-														},
-														"text_color": "#000000"
-													}
-												]
-											}
-										]
-									}
-								}
-							}
-						}
-					}
-				},
-				"tags": [
-					"OpenID4VC Issuers"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "query",
-						"name": "publicIssuerId",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/openid4vc/issuers/{issuerId}": {
-			"delete": {
-				"operationId": "DeleteIssuer",
-				"responses": {
-					"204": {
-						"description": "No content"
-					}
-				},
-				"description": "Delete an OpenID4VCI issuer by id",
-				"tags": [
-					"OpenID4VC Issuers"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "issuerId",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			},
-			"get": {
-				"operationId": "GetIssuer",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/OpenId4VcIssuerRecord"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"id": "65dff314-b7c8-4617-952e-a82864fecec5",
-											"createdAt": "2024-03-29T15:26:58.347Z",
-											"updatedAt": "2024-03-29T15:26:58.347Z",
-											"type": "OpenId4VcIssuerRecord",
-											"publicIssuerId": "129ea46f-92bc-4d44-8433-ac153b7da2e6",
-											"accessTokenPublicKeyFingerprint": "z6MkrSAZxmNERyktTeT2ich4Ntu3TPc5RdcB4sCsEbZa4vzh",
-											"credentialsSupported": [
-												{
-													"format": "vc+sd-jwt",
-													"id": "ExampleCredentialSdJwtVc",
-													"vct": "https://example.com/vct#ExampleCredential",
-													"cryptographic_binding_methods_supported": [
-														"did:key",
-														"did:jwk"
-													],
-													"cryptographic_suites_supported": [
-														"ES256",
-														"Ed25519"
-													],
-													"display": [
-														{
-															"name": "Example SD JWT Credential",
-															"description": "This is an example SD-JWT credential",
-															"background_color": "#ffffff",
-															"background_image": {
-																"url": "https://example.com/background.png",
-																"alt_text": "Example Credential Background"
-															},
-															"text_color": "#000000",
-															"locale": "en-US",
-															"logo": {
-																"url": "https://example.com/logo.png",
-																"alt_text": "Example Credential Logo"
-															}
-														}
-													]
-												},
-												{
-													"format": "jwt_vc_json",
-													"id": "ExampleCredentialJwtVc",
-													"types": [
-														"VerifiableCredential",
-														"ExampleCredential"
-													],
-													"cryptographic_binding_methods_supported": [
-														"did:key",
-														"did:jwk"
-													],
-													"cryptographic_suites_supported": [
-														"ES256",
-														"Ed25519"
-													],
-													"display": [
-														{
-															"name": "Example SD JWT Credential",
-															"description": "This is an example SD-JWT credential",
-															"background_color": "#ffffff",
-															"background_image": {
-																"url": "https://example.com/background.png",
-																"alt_text": "Example Credential Background"
-															},
-															"text_color": "#000000",
-															"locale": "en-US",
-															"logo": {
-																"url": "https://example.com/logo.png",
-																"alt_text": "Example Credential Logo"
-															}
-														}
-													]
-												}
-											],
-											"display": [
-												{
-													"background_color": "#ffffff",
-													"description": "This is an example issuer",
-													"name": "Example Issuer",
-													"locale": "en-US",
-													"logo": {
-														"alt_text": "Example Issuer Logo",
-														"url": "https://example.com/logo.png"
-													},
-													"text_color": "#000000"
-												}
-											]
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Get an OpenID4VCI issuer by id",
-				"tags": [
-					"OpenID4VC Issuers"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "issuerId",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			},
-			"put": {
-				"operationId": "UpdateIssuerMetadata",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/OpenId4VcIssuerRecord"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"id": "65dff314-b7c8-4617-952e-a82864fecec5",
-											"createdAt": "2024-03-29T15:26:58.347Z",
-											"updatedAt": "2024-03-29T15:26:58.347Z",
-											"type": "OpenId4VcIssuerRecord",
-											"publicIssuerId": "129ea46f-92bc-4d44-8433-ac153b7da2e6",
-											"accessTokenPublicKeyFingerprint": "z6MkrSAZxmNERyktTeT2ich4Ntu3TPc5RdcB4sCsEbZa4vzh",
-											"credentialsSupported": [
-												{
-													"format": "vc+sd-jwt",
-													"id": "ExampleCredentialSdJwtVc",
-													"vct": "https://example.com/vct#ExampleCredential",
-													"cryptographic_binding_methods_supported": [
-														"did:key",
-														"did:jwk"
-													],
-													"cryptographic_suites_supported": [
-														"ES256",
-														"Ed25519"
-													],
-													"display": [
-														{
-															"name": "Example SD JWT Credential",
-															"description": "This is an example SD-JWT credential",
-															"background_color": "#ffffff",
-															"background_image": {
-																"url": "https://example.com/background.png",
-																"alt_text": "Example Credential Background"
-															},
-															"text_color": "#000000",
-															"locale": "en-US",
-															"logo": {
-																"url": "https://example.com/logo.png",
-																"alt_text": "Example Credential Logo"
-															}
-														}
-													]
-												},
-												{
-													"format": "jwt_vc_json",
-													"id": "ExampleCredentialJwtVc",
-													"types": [
-														"VerifiableCredential",
-														"ExampleCredential"
-													],
-													"cryptographic_binding_methods_supported": [
-														"did:key",
-														"did:jwk"
-													],
-													"cryptographic_suites_supported": [
-														"ES256",
-														"Ed25519"
-													],
-													"display": [
-														{
-															"name": "Example SD JWT Credential",
-															"description": "This is an example SD-JWT credential",
-															"background_color": "#ffffff",
-															"background_image": {
-																"url": "https://example.com/background.png",
-																"alt_text": "Example Credential Background"
-															},
-															"text_color": "#000000",
-															"locale": "en-US",
-															"logo": {
-																"url": "https://example.com/logo.png",
-																"alt_text": "Example Credential Logo"
-															}
-														}
-													]
-												}
-											],
-											"display": [
-												{
-													"background_color": "#ffffff",
-													"description": "This is an example issuer",
-													"name": "Example Issuer",
-													"locale": "en-US",
-													"logo": {
-														"alt_text": "Example Issuer Logo",
-														"url": "https://example.com/logo.png"
-													},
-													"text_color": "#000000"
-												}
-											]
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Update issuer metadata (`display` and `credentialsSupported`).\n\nNOTE: this method overwrites the existing metadata with the new metadata, so\nmake sure to include all the metadata you want to keep in the new metadata.",
-				"tags": [
-					"OpenID4VC Issuers"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "issuerId",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/OpenId4VcIssuersUpdateMetadataOptions"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/openid4vc/issuers/sessions/create-offer": {
-			"post": {
-				"operationId": "CreateOffer",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/OpenId4VcIssuanceSessionsCreateOfferResponse"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"issuanceSession": {
-												"id": "9cde9070-23c9-4e51-b810-e929a0298cbb",
-												"createdAt": "2024-03-29T17:54:34.890Z",
-												"updatedAt": "2024-03-29T17:54:34.890Z",
-												"type": "OpenId4VcIssuanceSessionRecord",
-												"publicIssuerId": "a868257d-7149-4d4d-a52c-78f3197ee538",
-												"state": "OfferCreated",
-												"preAuthorizedCode": "963352229993506863726932",
-												"issuanceMetadata": {
-													"credentials": [
-														{
-															"credentialSupportedId": "ExampleCredentialSdJwtVc",
-															"format": "vc+sd-jwt",
-															"issuer": {
-																"method": "did",
-																"didUrl": "did:key:z6MkgViwfstCL1L9i8tgsdAYEu5A62W5mA9DcmSygVVVLFuU#z6MkgViwfstCL1L9i8tgsdAYEu5A62W5mA9DcmSygVVVLFuU"
-															},
-															"payload": {
-																"first_name": "John",
-																"last_name": "Doe",
-																"age": {
-																	"over_18": true,
-																	"over_21": true,
-																	"over_65": false
-																},
-																"vct": "https://example.com/vct#ExampleCredential"
-															},
-															"disclosureFrame": {
-																"first_name": false,
-																"last_name": false,
-																"age": {
-																	"over_18": true,
-																	"over_21": true,
-																	"over_65": true
-																}
-															}
-														}
-													]
-												},
-												"credentialOfferPayload": {
-													"grants": {
-														"urn:ietf:params:oauth:grant-type:pre-authorized_code": {
-															"pre-authorized_code": "963352229993506863726932",
-															"user_pin_required": false
-														}
-													},
-													"credentials": [
-														"ExampleCredentialSdJwtVc"
-													],
-													"credential_issuer": "http://localhost:3008/oid4vci/a868257d-7149-4d4d-a52c-78f3197ee538"
-												},
-												"credentialOfferUri": "http://localhost:3008/oid4vci/a868257d-7149-4d4d-a52c-78f3197ee538/offers/4a85ea23-998c-4bbe-af0a-9b03a2b030db"
-											},
-											"credentialOffer": "openid-credential-offer://?credential_offer_uri=http%3A%2F%2Flocalhost%3A3008%2Foid4vci%2Fa868257d-7149-4d4d-a52c-78f3197ee538%2Foffers%2F4a85ea23-998c-4bbe-af0a-9b03a2b030db"
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Create an OpenID4VC issuance session by creating a credential offer",
-				"tags": [
-					"OpenID4VC Issuance Sessions"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/OpenId4VcIssuanceSessionsCreateOfferOptions"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/openid4vc/issuers/sessions": {
-			"get": {
-				"operationId": "GetIssuanceSessionsByQuery",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"items": {
-										"$ref": "#/components/schemas/OpenId4VcIssuanceSessionRecord"
-									},
-									"type": "array"
-								}
-							}
-						}
-					}
-				},
-				"description": "Find all OpenID4VC issuance sessions by query",
-				"tags": [
-					"OpenID4VC Issuance Sessions"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "query",
-						"name": "cNonce",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"in": "query",
-						"name": "publicIssuerId",
-						"required": false,
-						"schema": {
-							"$ref": "#/components/schemas/PublicIssuerId"
-						}
-					},
-					{
-						"in": "query",
-						"name": "preAuthorizedCode",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"in": "query",
-						"name": "state",
-						"required": false,
-						"schema": {
-							"$ref": "#/components/schemas/OpenId4VcIssuanceSessionState"
-						}
-					},
-					{
-						"in": "query",
-						"name": "credentialOfferUri",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/openid4vc/issuers/sessions/{issuanceSessionId}": {
-			"get": {
-				"operationId": "GetIssuanceSession",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/OpenId4VcIssuanceSessionRecord"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get an OpenID4VC issuance session by issuance session id",
-				"tags": [
-					"OpenID4VC Issuance Sessions"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "issuanceSessionId",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			},
-			"delete": {
-				"operationId": "DeleteIssuanceSession",
-				"responses": {
-					"204": {
-						"description": "No content"
-					}
-				},
-				"description": "Delete an OpenID4VC issuance session by id",
-				"tags": [
-					"OpenID4VC Issuance Sessions"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "issuanceSessionId",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/didcomm/proofs": {
-			"get": {
-				"operationId": "FindProofsByQuery",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"items": {
-										"$ref": "#/components/schemas/DidCommProofExchangeRecord"
-									},
-									"type": "array"
-								},
-								"examples": {
-									"Example 1": {
-										"value": [
-											{
-												"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
-												"protocolVersion": "v2",
-												"role": "prover",
-												"state": "proposal-sent",
-												"threadId": "0019d466-5eea-4269-8c40-031b4896c5b7",
-												"connectionId": "2aecf74c-3073-4f98-9acb-92415d096834",
-												"createdAt": "2022-01-01T00:00:00.000Z",
-												"autoAcceptProof": "always",
-												"type": "ProofRecord"
-											}
-										]
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Find proof exchanges by query",
-				"tags": [
-					"DIDComm Proofs"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "query",
-						"name": "threadId",
-						"required": false,
-						"schema": {
-							"$ref": "#/components/schemas/ThreadId"
-						}
-					},
-					{
-						"in": "query",
-						"name": "connectionId",
-						"required": false,
-						"schema": {
-							"$ref": "#/components/schemas/RecordId"
-						}
-					},
-					{
-						"in": "query",
-						"name": "state",
-						"required": false,
-						"schema": {
-							"$ref": "#/components/schemas/ProofState"
-						}
-					},
-					{
-						"in": "query",
-						"name": "parentThreadId",
-						"required": false,
-						"schema": {
-							"$ref": "#/components/schemas/ThreadId"
-						}
-					},
-					{
-						"in": "query",
-						"name": "role",
-						"required": false,
-						"schema": {
-							"$ref": "#/components/schemas/ProofRole"
-						}
-					}
-				]
-			}
-		},
-		"/didcomm/proofs/{proofExchangeId}/format-data": {
-			"get": {
-				"operationId": "GetFormatDateForProofExchange",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/DidCommProofsGetFormatDataResponse"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"request": {
-												"anoncreds": {
-													"name": "proof",
-													"version": "1.0",
-													"nonce": "758240050114745983655710",
-													"requested_attributes": {
-														"prop1": {
-															"restrictions": [
-																{
-																	"cred_def_id": "credential-definition:_p5hLM-uQa1zWnn3tBlSZjLHN3_jrHOq48HZg9x0WNU"
-																}
-															],
-															"name": "prop1"
-														}
-													},
-													"requested_predicates": {}
-												}
-											},
-											"presentation": {
-												"anoncreds": {
-													"proof": {
-														"proofs": [
-															{
-																"primary_proof": {
-																	"eq_proof": {
-																		"revealed_attrs": {
-																			"prop1": "27034640024117331033063128044004318218486816931520886405535659934417438781507"
-																		},
-																		"a_prime": "19047116433504188994272881641822894872902270927119448171860075215300057790220032716001623222457003097557526300243774256052213342685786339664359702293068763238941477983249827037208391202082237355452899615066813136375104369999353835295981406017700484554961999776491254535901817543204922312909798679047221330019235737943019299392326535879346715038129185356279868745469303380007785962003959306434843861572801946425200870616819278614278447453156100921293441241791644660148472591502140793919913129642727070863794832260096533561211015144668753888527444212286891447285472223278089710845256263784748983746718325771142088732939",
-																		"e": "10259898129295787961743851056978055195603429485644503254324436416167764909267793244904075766652236796402891954383818563601919019183718168",
-																		"v": "1231362115035007024570764941449044031590844390550471600312531446117722154659868456888335013946335458040274898035202658225595068963856089705169119329625310606633779849291885735720644454949213413794453812488717746459159104479357614205354859977539345197819006257295943057033308104945137276434448035162025255321821437631597083690718246293836723511817575318157392852647929432326303080306792286331173382522988459574485523423956289579780768305214142906216511255127647152962121322858014142270114082615381637234314728038304949470391361208405519610497147621327793260813179177368913095571745867719207542759576560425897236709768313140801020933801485735855445633964031941661640923635020541019781997653754765174059228323815763523970880399098098455858988336056250017116998250153813329152217051921736584301286899814639213197350128774690139583010473926868949760824128601421310373158774629991706471289635887140592649446912506997480513587053",
-																		"m": {
-																			"prop2": "16162691443890709574767645052161691434918099895053484805751392155204331411424414052735813491020922097673389640501460090756960039580468937518501805646597654106586801848678500913986",
-																			"master_secret": "10922412082717230367748516141129893501521277218767044762649924912605238791909366369223988111691711544332629968246354239716138904917009438604729675733830274629976624843073297367700"
-																		},
-																		"m2": "143283050199231500752147520595402404430732435435603814807867477210654907867800083910082782289810115670692637233938031314254705029316478576894690559684263226485325994959779501355610180066672024099090659111271057300388050170242803008137083396212408809319025355910950905661669766118741906012674213690293786101106250316977895458665512868288955286373377155511034215107395178211834003022495581825841682012396310023015657545525739013246143790276942948375829743916303018361158237084452134993073397899480348489140658247064717903765898129567455078992931912070154142338171836287509698783369557812496197648966004949431901163349211745070465330233452514957502613847594191716703134436607494648786994546260304783197646882841310437319877565249799794"
-																	},
-																	"ge_proofs": []
-																},
-																"non_revoc_proof": null
-															}
-														],
-														"aggregated_proof": {
-															"c_hash": "76178432210457409800554029394836415101930849642483382585409939514864801686752",
-															"c_list": [
-																[
-																	150,
-																	225,
-																	217,
-																	140,
-																	172,
-																	223,
-																	12,
-																	66,
-																	140,
-																	46,
-																	192,
-																	81,
-																	148,
-																	134,
-																	190,
-																	64,
-																	6,
-																	79,
-																	137,
-																	224,
-																	183,
-																	196,
-																	1,
-																	53,
-																	74,
-																	202,
-																	142,
-																	207,
-																	205,
-																	85,
-																	68,
-																	149,
-																	183,
-																	231,
-																	102,
-																	151,
-																	99,
-																	207,
-																	81,
-																	103,
-																	28,
-																	162,
-																	11,
-																	32,
-																	124,
-																	123,
-																	124,
-																	16,
-																	110,
-																	54,
-																	177,
-																	85,
-																	202,
-																	169,
-																	186,
-																	146,
-																	134,
-																	43,
-																	149,
-																	79,
-																	220,
-																	161,
-																	129,
-																	15,
-																	229,
-																	253,
-																	44,
-																	250,
-																	129,
-																	223,
-																	194,
-																	175,
-																	101,
-																	181,
-																	78,
-																	155,
-																	71,
-																	122,
-																	9,
-																	131,
-																	166,
-																	178,
-																	239,
-																	35,
-																	72,
-																	64,
-																	93,
-																	160,
-																	230,
-																	202,
-																	255,
-																	4,
-																	121,
-																	243,
-																	107,
-																	81,
-																	38,
-																	10,
-																	98,
-																	80,
-																	62,
-																	15,
-																	180,
-																	7,
-																	148,
-																	52,
-																	164,
-																	154,
-																	45,
-																	154,
-																	104,
-																	10,
-																	156,
-																	144,
-																	223,
-																	255,
-																	132,
-																	248,
-																	109,
-																	87,
-																	40,
-																	167,
-																	194,
-																	139,
-																	49,
-																	3,
-																	153,
-																	175,
-																	119,
-																	231,
-																	156,
-																	204,
-																	54,
-																	41,
-																	26,
-																	79,
-																	19,
-																	169,
-																	153,
-																	192,
-																	102,
-																	105,
-																	168,
-																	90,
-																	5,
-																	21,
-																	249,
-																	187,
-																	26,
-																	176,
-																	136,
-																	204,
-																	113,
-																	73,
-																	240,
-																	143,
-																	56,
-																	121,
-																	23,
-																	77,
-																	112,
-																	126,
-																	222,
-																	54,
-																	233,
-																	110,
-																	73,
-																	70,
-																	77,
-																	9,
-																	135,
-																	65,
-																	186,
-																	27,
-																	22,
-																	140,
-																	137,
-																	169,
-																	230,
-																	49,
-																	191,
-																	60,
-																	66,
-																	8,
-																	136,
-																	88,
-																	183,
-																	240,
-																	225,
-																	80,
-																	151,
-																	123,
-																	45,
-																	110,
-																	91,
-																	222,
-																	242,
-																	236,
-																	20,
-																	123,
-																	104,
-																	154,
-																	187,
-																	164,
-																	96,
-																	46,
-																	218,
-																	129,
-																	133,
-																	233,
-																	225,
-																	252,
-																	77,
-																	139,
-																	163,
-																	93,
-																	117,
-																	171,
-																	78,
-																	170,
-																	16,
-																	99,
-																	127,
-																	232,
-																	161,
-																	106,
-																	41,
-																	94,
-																	177,
-																	179,
-																	9,
-																	216,
-																	233,
-																	175,
-																	192,
-																	36,
-																	45,
-																	192,
-																	148,
-																	173,
-																	217,
-																	7,
-																	43,
-																	188,
-																	80,
-																	79,
-																	183,
-																	230,
-																	183,
-																	166,
-																	117,
-																	48,
-																	1,
-																	253,
-																	177,
-																	11
-																]
-															]
-														}
-													},
-													"requested_proof": {
-														"revealed_attrs": {
-															"prop1": {
-																"sub_proof_index": 0,
-																"raw": "Alice",
-																"encoded": "27034640024117331033063128044004318218486816931520886405535659934417438781507"
-															}
-														},
-														"self_attested_attrs": {},
-														"unrevealed_attrs": {},
-														"predicates": {}
-													},
-													"identifiers": [
-														{
-															"schema_id": "schema:gSl0JkGIcmRif593Q6XYGsJndHGOzm1jWRFa-Lwrz9o",
-															"cred_def_id": "credential-definition:_p5hLM-uQa1zWnn3tBlSZjLHN3_jrHOq48HZg9x0WNU"
-														}
-													]
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Retrieve the format data associated with a proof exchange",
-				"tags": [
-					"DIDComm Proofs"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "proofExchangeId",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/RecordId"
-						}
-					}
-				]
-			}
-		},
-		"/didcomm/proofs/{proofExchangeId}": {
-			"get": {
-				"operationId": "GetProofExchangeById",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/DidCommProofExchangeRecord"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
-											"protocolVersion": "v2",
-											"role": "prover",
-											"state": "proposal-sent",
-											"threadId": "0019d466-5eea-4269-8c40-031b4896c5b7",
-											"connectionId": "2aecf74c-3073-4f98-9acb-92415d096834",
-											"createdAt": "2022-01-01T00:00:00.000Z",
-											"autoAcceptProof": "always",
-											"type": "ProofRecord"
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Retrieve proof exchange by proof exchange id",
-				"tags": [
-					"DIDComm Proofs"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "proofExchangeId",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/RecordId"
-						}
-					}
-				]
-			},
-			"delete": {
-				"operationId": "DeleteProof",
-				"responses": {
-					"204": {
-						"description": "No content"
-					}
-				},
-				"description": "Deletes a proof exchange record.",
-				"tags": [
-					"DIDComm Proofs"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "proofExchangeId",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/RecordId"
-						}
-					}
-				]
-			}
-		},
-		"/didcomm/proofs/propose-proof": {
-			"post": {
-				"operationId": "ProposeProof",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/DidCommProofExchangeRecord"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
-											"protocolVersion": "v2",
-											"role": "prover",
-											"state": "proposal-sent",
-											"threadId": "0019d466-5eea-4269-8c40-031b4896c5b7",
-											"connectionId": "2aecf74c-3073-4f98-9acb-92415d096834",
-											"createdAt": "2022-01-01T00:00:00.000Z",
-											"autoAcceptProof": "always",
-											"type": "ProofRecord"
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Initiate a new presentation exchange as prover by sending a presentation proposal request\nto the connection with the specified connection id.",
-				"tags": [
-					"DIDComm Proofs"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/DidCommProofsProposeProofOptions"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/didcomm/proofs/{proofExchangeId}/accept-proposal": {
-			"post": {
-				"operationId": "AcceptProposal",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/DidCommProofExchangeRecord"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
-											"protocolVersion": "v2",
-											"role": "prover",
-											"state": "proposal-sent",
-											"threadId": "0019d466-5eea-4269-8c40-031b4896c5b7",
-											"connectionId": "2aecf74c-3073-4f98-9acb-92415d096834",
-											"createdAt": "2022-01-01T00:00:00.000Z",
-											"autoAcceptProof": "always",
-											"type": "ProofRecord"
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Accept a presentation proposal as verifier by sending an accept proposal message\nto the connection associated with the proof record.",
-				"tags": [
-					"DIDComm Proofs"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "proofExchangeId",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/RecordId"
-						}
-					}
-				],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/DidCommProofsAcceptProposalOptions"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/didcomm/proofs/create-request": {
-			"post": {
-				"operationId": "CreateRequest",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/DidCommProofsCreateRequestResponse"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"proofExchange": {
-												"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
-												"protocolVersion": "v2",
-												"role": "prover",
-												"state": "proposal-sent",
-												"threadId": "0019d466-5eea-4269-8c40-031b4896c5b7",
-												"connectionId": "2aecf74c-3073-4f98-9acb-92415d096834",
-												"createdAt": "2022-01-01T00:00:00.000Z",
-												"autoAcceptProof": "always",
-												"type": "ProofRecord"
-											},
-											"message": {
-												"@id": "134b27f0-9366-4811-a36b-50bacfe57e61",
-												"@type": "https://didcomm.org/present-proof/1.0/request-presentation"
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Creates a presentation request not bound to any proposal or existing connection",
-				"tags": [
-					"DIDComm Proofs"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/DidCommProofsCreateRequestOptions"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/didcomm/proofs/request-proof": {
-			"post": {
-				"operationId": "RequestProof",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
-											"protocolVersion": "v2",
-											"role": "prover",
-											"state": "proposal-sent",
-											"threadId": "0019d466-5eea-4269-8c40-031b4896c5b7",
-											"connectionId": "2aecf74c-3073-4f98-9acb-92415d096834",
-											"createdAt": "2022-01-01T00:00:00.000Z",
-											"autoAcceptProof": "always",
-											"type": "ProofRecord"
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Creates a presentation request bound to existing connection",
-				"tags": [
-					"DIDComm Proofs"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/DidCommProofsSendRequestOptions"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/didcomm/proofs/{proofExchangeId}/accept-request": {
-			"post": {
-				"operationId": "AcceptRequest",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
-											"protocolVersion": "v2",
-											"role": "prover",
-											"state": "proposal-sent",
-											"threadId": "0019d466-5eea-4269-8c40-031b4896c5b7",
-											"connectionId": "2aecf74c-3073-4f98-9acb-92415d096834",
-											"createdAt": "2022-01-01T00:00:00.000Z",
-											"autoAcceptProof": "always",
-											"type": "ProofRecord"
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Accept a presentation request as prover by sending an accept request message\nto the connection associated with the proof record.",
-				"tags": [
-					"DIDComm Proofs"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "proofExchangeId",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/RecordId"
-						}
-					}
-				],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/DidCommProofsAcceptRequestOptions"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/didcomm/proofs/{proofExchangeId}/accept-presentation": {
-			"post": {
-				"operationId": "AcceptPresentation",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
-											"protocolVersion": "v2",
-											"role": "prover",
-											"state": "proposal-sent",
-											"threadId": "0019d466-5eea-4269-8c40-031b4896c5b7",
-											"connectionId": "2aecf74c-3073-4f98-9acb-92415d096834",
-											"createdAt": "2022-01-01T00:00:00.000Z",
-											"autoAcceptProof": "always",
-											"type": "ProofRecord"
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Accept a presentation as prover by sending an accept presentation message\nto the connection associated with the proof record.",
-				"tags": [
-					"DIDComm Proofs"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "proofExchangeId",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/RecordId"
-						}
-					}
-				]
-			}
-		},
-		"/didcomm/out-of-band": {
-			"get": {
-				"operationId": "FindOutOfBandRecordsByQuery",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"items": {
-										"$ref": "#/components/schemas/DidCommOutOfBandRecord"
-									},
-									"type": "array"
-								},
-								"examples": {
-									"Example 1": {
-										"value": [
-											{
-												"outOfBandInvitation": {
-													"@type": "https://didcomm.org/out-of-band/1.1/invitation",
-													"@id": "d6472943-e5d0-4d95-8b48-790ed5a41931",
-													"label": "Aries Test Agent",
-													"accept": [
-														"didcomm/aip1",
-														"didcomm/aip2;env=rfc19"
-													],
-													"handshake_protocols": [
-														"https://didcomm.org/didexchange/1.0",
-														"https://didcomm.org/connections/1.0"
-													],
-													"services": [
-														{
-															"id": "#inline-0",
-															"serviceEndpoint": "https://6b77-89-20-162-146.ngrok.io",
-															"type": "did-communication",
-															"recipientKeys": [
-																"did:key:z6MkmTBHTWrvLPN8pBmUj7Ye5ww9GiacXCYMNVvpScSpf1DM"
-															],
-															"routingKeys": []
-														}
-													]
-												},
-												"id": "42a95528-0e30-4f86-a462-0efb02178b53",
-												"createdAt": "2022-01-01T00:00:00.000Z",
-												"role": "sender",
-												"state": "prepare-response",
-												"reusable": false,
-												"type": "OutOfBandRecord"
-											}
-										]
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Retrieve all out of band records by query",
-				"tags": [
-					"DIDComm Out Of Band"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "query",
-						"name": "invitationId",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"in": "query",
-						"name": "role",
-						"required": false,
-						"schema": {
-							"$ref": "#/components/schemas/OutOfBandRole"
-						}
-					},
-					{
-						"in": "query",
-						"name": "state",
-						"required": false,
-						"schema": {
-							"$ref": "#/components/schemas/OutOfBandState"
-						}
-					},
-					{
-						"in": "query",
-						"name": "threadId",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/didcomm/out-of-band/{outOfBandId}": {
-			"get": {
-				"operationId": "GetOutOfBandRecordById",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/DidCommOutOfBandRecord"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"outOfBandInvitation": {
-												"@type": "https://didcomm.org/out-of-band/1.1/invitation",
-												"@id": "d6472943-e5d0-4d95-8b48-790ed5a41931",
-												"label": "Aries Test Agent",
-												"accept": [
-													"didcomm/aip1",
-													"didcomm/aip2;env=rfc19"
-												],
-												"handshake_protocols": [
-													"https://didcomm.org/didexchange/1.0",
-													"https://didcomm.org/connections/1.0"
-												],
-												"services": [
-													{
-														"id": "#inline-0",
-														"serviceEndpoint": "https://6b77-89-20-162-146.ngrok.io",
-														"type": "did-communication",
-														"recipientKeys": [
-															"did:key:z6MkmTBHTWrvLPN8pBmUj7Ye5ww9GiacXCYMNVvpScSpf1DM"
-														],
-														"routingKeys": []
-													}
-												]
-											},
-											"id": "42a95528-0e30-4f86-a462-0efb02178b53",
-											"createdAt": "2022-01-01T00:00:00.000Z",
-											"role": "sender",
-											"state": "prepare-response",
-											"reusable": false,
-											"type": "OutOfBandRecord"
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Retrieve an out of band record by id",
-				"tags": [
-					"DIDComm Out Of Band"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "outOfBandId",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/RecordId"
-						}
-					}
-				]
-			},
-			"delete": {
-				"operationId": "DeleteOutOfBandRecord",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {}
-							}
-						}
-					}
-				},
-				"description": "Deletes an out of band record from the repository.",
-				"tags": [
-					"DIDComm Out Of Band"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "outOfBandId",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/RecordId"
-						}
-					}
-				]
-			}
-		},
-		"/didcomm/out-of-band/create-invitation": {
-			"post": {
-				"operationId": "CreateInvitation",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/DidCommOutOfBandCreateInvitationResponse"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"invitationUrl": "https://example.com/?",
-											"invitation": {
-												"@type": "https://didcomm.org/out-of-band/1.1/invitation",
-												"@id": "d6472943-e5d0-4d95-8b48-790ed5a41931",
-												"label": "Aries Test Agent",
-												"accept": [
-													"didcomm/aip1",
-													"didcomm/aip2;env=rfc19"
-												],
-												"handshake_protocols": [
-													"https://didcomm.org/didexchange/1.0",
-													"https://didcomm.org/connections/1.0"
-												],
-												"services": [
-													{
-														"id": "#inline-0",
-														"serviceEndpoint": "https://6b77-89-20-162-146.ngrok.io",
-														"type": "did-communication",
-														"recipientKeys": [
-															"did:key:z6MkmTBHTWrvLPN8pBmUj7Ye5ww9GiacXCYMNVvpScSpf1DM"
-														],
-														"routingKeys": []
-													}
-												]
-											},
-											"outOfBandRecord": {
-												"outOfBandInvitation": {
-													"@type": "https://didcomm.org/out-of-band/1.1/invitation",
-													"@id": "d6472943-e5d0-4d95-8b48-790ed5a41931",
-													"label": "Aries Test Agent",
-													"accept": [
-														"didcomm/aip1",
-														"didcomm/aip2;env=rfc19"
-													],
-													"handshake_protocols": [
-														"https://didcomm.org/didexchange/1.0",
-														"https://didcomm.org/connections/1.0"
-													],
-													"services": [
-														{
-															"id": "#inline-0",
-															"serviceEndpoint": "https://6b77-89-20-162-146.ngrok.io",
-															"type": "did-communication",
-															"recipientKeys": [
-																"did:key:z6MkmTBHTWrvLPN8pBmUj7Ye5ww9GiacXCYMNVvpScSpf1DM"
-															],
-															"routingKeys": []
-														}
-													]
-												},
-												"id": "42a95528-0e30-4f86-a462-0efb02178b53",
-												"createdAt": "2022-01-01T00:00:00.000Z",
-												"role": "sender",
-												"state": "prepare-response",
-												"reusable": false,
-												"type": "OutOfBandRecord"
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Creates an outbound out-of-band record containing out-of-band invitation message defined in\nAries RFC 0434: Out-of-Band Protocol 1.1.",
-				"tags": [
-					"DIDComm Out Of Band"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [],
-				"requestBody": {
-					"required": false,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/DidCommOutOfBandCreateInvitationOptions"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/didcomm/out-of-band/create-legacy-invitation": {
-			"post": {
-				"operationId": "CreateLegacyInvitation",
-				"responses": {
-					"200": {
-						"description": "out-of-band record and invitation",
-						"content": {
-							"application/json": {
-								"schema": {},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"invitation": {
-												"@type": "https://didcomm.org/connections/1./invitation",
-												"@id": "d6b23733-be49-408b-98ab-ba9460384087"
-											},
-											"outOfBandRecord": {
-												"outOfBandInvitation": {
-													"@type": "https://didcomm.org/out-of-band/1.1/invitation",
-													"@id": "d6472943-e5d0-4d95-8b48-790ed5a41931",
-													"label": "Aries Test Agent",
-													"accept": [
-														"didcomm/aip1",
-														"didcomm/aip2;env=rfc19"
-													],
-													"handshake_protocols": [
-														"https://didcomm.org/didexchange/1.0",
-														"https://didcomm.org/connections/1.0"
-													],
-													"services": [
-														{
-															"id": "#inline-0",
-															"serviceEndpoint": "https://6b77-89-20-162-146.ngrok.io",
-															"type": "did-communication",
-															"recipientKeys": [
-																"did:key:z6MkmTBHTWrvLPN8pBmUj7Ye5ww9GiacXCYMNVvpScSpf1DM"
-															],
-															"routingKeys": []
-														}
-													]
-												},
-												"id": "42a95528-0e30-4f86-a462-0efb02178b53",
-												"createdAt": "2022-01-01T00:00:00.000Z",
-												"role": "sender",
-												"state": "prepare-response",
-												"reusable": false,
-												"type": "OutOfBandRecord"
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Creates an outbound out-of-band record in the same way how `createInvitation` method does it,\nbut it also converts out-of-band invitation message to an \"legacy\" invitation message defined\nin RFC 0160: Connection Protocol and returns it together with out-of-band record.",
-				"tags": [
-					"DIDComm Out Of Band"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [],
-				"requestBody": {
-					"required": false,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/DidCommOutOfBandCreateLegacyConnectionInvitationOptions"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/didcomm/out-of-band/create-legacy-connectionless-invitation": {
-			"post": {
-				"operationId": "CreateLegacyConnectionlessInvitation",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"message": {
-												"@id": "eac4ff4e-b4fb-4c1d-aef3-b29c89d1cc00",
-												"@type": "https://didcomm.org/issue-credential/1.0/offer-credential"
-											},
-											"invitationUrl": "http://example.com/invitation_url"
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Creates a new connectionless legacy invitation.\n\nOnly works with messages created from:\n- /didcomm/credentials/create-offer\n- /didcomm/poofs/create-request",
-				"tags": [
-					"DIDComm Out Of Band"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/DidCommOutOfBandCreateLegacyConnectionlessInvitationOptions"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/didcomm/out-of-band/receive-invitation": {
-			"post": {
-				"operationId": "ReceiveInvitation",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"outOfBandRecord": {
-												"outOfBandInvitation": {
-													"@type": "https://didcomm.org/out-of-band/1.1/invitation",
-													"@id": "d6472943-e5d0-4d95-8b48-790ed5a41931",
-													"label": "Aries Test Agent",
-													"accept": [
-														"didcomm/aip1",
-														"didcomm/aip2;env=rfc19"
-													],
-													"handshake_protocols": [
-														"https://didcomm.org/didexchange/1.0",
-														"https://didcomm.org/connections/1.0"
-													],
-													"services": [
-														{
-															"id": "#inline-0",
-															"serviceEndpoint": "https://6b77-89-20-162-146.ngrok.io",
-															"type": "did-communication",
-															"recipientKeys": [
-																"did:key:z6MkmTBHTWrvLPN8pBmUj7Ye5ww9GiacXCYMNVvpScSpf1DM"
-															],
-															"routingKeys": []
-														}
-													]
-												},
-												"id": "42a95528-0e30-4f86-a462-0efb02178b53",
-												"createdAt": "2022-01-01T00:00:00.000Z",
-												"role": "sender",
-												"state": "prepare-response",
-												"reusable": false,
-												"type": "OutOfBandRecord"
-											},
-											"connectionRecord": {
-												"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
-												"type": "ConnectionRecord",
-												"createdAt": "2022-01-01T00:00:00.000Z",
-												"did": "did:peer:1zQmfQh1T3rSqarP2FZ37uKjdQHPKFdVyo2mGiAPHZ8Ep7hv",
-												"state": "invitation-sent",
-												"role": "responder",
-												"invitationDid": "did:peer:2.SeyJzIjoiaHR0cHM6Ly9kYTIzLTg5LTIwLTE2Mi0xNDYubmdyb2suaW8iLCJ0IjoiZGlkLWNvbW11bmljYXRpb24iLCJwcmlvcml0eSI6MCwicmVjaXBpZW50S2V5cyI6WyJkaWQ6a2V5Ono2TWtualg3U1lXRmdHMThCYkNEZHJnemhuQnA0UlhyOGVITHZxQ3FvRXllckxiTiN6Nk1rbmpYN1NZV0ZnRzE4QmJDRGRyZ3pobkJwNFJYcjhlSEx2cUNxb0V5ZXJMYk4iXSwiciI6W119",
-												"outOfBandId": "edbc89fe-785f-4774-a288-46012486881d"
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Receive an out of band invitation. Supports urls as well as JSON messages. Also supports legacy\nconnection invitations",
-				"tags": [
-					"DIDComm Out Of Band"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/DidCommOutOfBandReceiveInvitationOptions"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/didcomm/out-of-band/{outOfBandId}/accept-invitation": {
-			"post": {
-				"operationId": "AcceptInvitation",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"outOfBandRecord": {
-												"outOfBandInvitation": {
-													"@type": "https://didcomm.org/out-of-band/1.1/invitation",
-													"@id": "d6472943-e5d0-4d95-8b48-790ed5a41931",
-													"label": "Aries Test Agent",
-													"accept": [
-														"didcomm/aip1",
-														"didcomm/aip2;env=rfc19"
-													],
-													"handshake_protocols": [
-														"https://didcomm.org/didexchange/1.0",
-														"https://didcomm.org/connections/1.0"
-													],
-													"services": [
-														{
-															"id": "#inline-0",
-															"serviceEndpoint": "https://6b77-89-20-162-146.ngrok.io",
-															"type": "did-communication",
-															"recipientKeys": [
-																"did:key:z6MkmTBHTWrvLPN8pBmUj7Ye5ww9GiacXCYMNVvpScSpf1DM"
-															],
-															"routingKeys": []
-														}
-													]
-												},
-												"id": "42a95528-0e30-4f86-a462-0efb02178b53",
-												"createdAt": "2022-01-01T00:00:00.000Z",
-												"role": "sender",
-												"state": "prepare-response",
-												"reusable": false,
-												"type": "OutOfBandRecord"
-											},
-											"connectionRecord": {
-												"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
-												"type": "ConnectionRecord",
-												"createdAt": "2022-01-01T00:00:00.000Z",
-												"did": "did:peer:1zQmfQh1T3rSqarP2FZ37uKjdQHPKFdVyo2mGiAPHZ8Ep7hv",
-												"state": "invitation-sent",
-												"role": "responder",
-												"invitationDid": "did:peer:2.SeyJzIjoiaHR0cHM6Ly9kYTIzLTg5LTIwLTE2Mi0xNDYubmdyb2suaW8iLCJ0IjoiZGlkLWNvbW11bmljYXRpb24iLCJwcmlvcml0eSI6MCwicmVjaXBpZW50S2V5cyI6WyJkaWQ6a2V5Ono2TWtualg3U1lXRmdHMThCYkNEZHJnemhuQnA0UlhyOGVITHZxQ3FvRXllckxiTiN6Nk1rbmpYN1NZV0ZnRzE4QmJDRGRyZ3pobkJwNFJYcjhlSEx2cUNxb0V5ZXJMYk4iXSwiciI6W119",
-												"outOfBandId": "edbc89fe-785f-4774-a288-46012486881d"
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Accept a connection invitation as invitee (by sending a connection request message) for the connection with the specified connection id.\nThis is not needed when auto accepting of connections is enabled.",
-				"tags": [
-					"DIDComm Out Of Band"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "outOfBandId",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/RecordId"
-						}
-					}
-				],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/DidCommOutOfBandAcceptInvitationOptions"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/didcomm/credentials": {
-			"get": {
-				"operationId": "FindCredentialsByQuery",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"items": {
-										"$ref": "#/components/schemas/DidCommCredentialExchangeRecord"
-									},
-									"type": "array"
-								},
-								"examples": {
-									"Example 1": {
-										"value": [
-											{
-												"credentials": [],
-												"type": "CredentialRecord",
-												"role": "holder",
-												"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
-												"createdAt": "2022-01-01T00:00:00.000Z",
-												"state": "offer-sent",
-												"connectionId": "ac6d0fdd-0db8-4f52-8a3d-de7ff8ddc14b",
-												"threadId": "82701488-b43c-4d7b-9244-4bb204a7ae26",
-												"credentialAttributes": [],
-												"protocolVersion": "v1"
-											}
-										]
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Retrieve all credential exchange records by query",
-				"tags": [
-					"DIDComm Credentials"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "query",
-						"name": "threadId",
-						"required": false,
-						"schema": {
-							"$ref": "#/components/schemas/ThreadId"
-						}
-					},
-					{
-						"in": "query",
-						"name": "parentThreadId",
-						"required": false,
-						"schema": {
-							"$ref": "#/components/schemas/ThreadId"
-						}
-					},
-					{
-						"in": "query",
-						"name": "connectionId",
-						"required": false,
-						"schema": {
-							"$ref": "#/components/schemas/RecordId"
-						}
-					},
-					{
-						"in": "query",
-						"name": "state",
-						"required": false,
-						"schema": {
-							"$ref": "#/components/schemas/CredentialState"
-						}
-					},
-					{
-						"in": "query",
-						"name": "role",
-						"required": false,
-						"schema": {
-							"$ref": "#/components/schemas/CredentialRole"
-						}
-					}
-				]
-			}
-		},
-		"/didcomm/credentials/{credentialExchangeId}": {
-			"get": {
-				"operationId": "GetCredentialById",
-				"responses": {
-					"200": {
-						"description": "CredentialExchangeRecord",
-						"content": {
-							"application/json": {
-								"schema": {},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"credentials": [],
-											"type": "CredentialRecord",
-											"role": "holder",
-											"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
-											"createdAt": "2022-01-01T00:00:00.000Z",
-											"state": "offer-sent",
-											"connectionId": "ac6d0fdd-0db8-4f52-8a3d-de7ff8ddc14b",
-											"threadId": "82701488-b43c-4d7b-9244-4bb204a7ae26",
-											"credentialAttributes": [],
-											"protocolVersion": "v1"
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Retrieve credential exchange record by credential record id",
-				"tags": [
-					"DIDComm Credentials"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "credentialExchangeId",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/RecordId"
-						}
-					}
-				]
-			},
-			"delete": {
-				"operationId": "DeleteCredential",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {}
-							}
-						}
-					}
-				},
-				"description": "Deletes a credential exchange record in the credential repository.",
-				"tags": [
-					"DIDComm Credentials"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "credentialExchangeId",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/RecordId"
-						}
-					}
-				]
-			}
-		},
-		"/didcomm/credentials/{credentialExchangeId}/format-data": {
-			"get": {
-				"operationId": "GetFormatDateForCredentialExchange",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/DidCommCredentialsGetFormatDataResponse"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"offerAttributes": [
-												{
-													"mime-type": "text/plain",
-													"name": "prop1",
-													"value": "Alice"
-												},
-												{
-													"mime-type": "text/plain",
-													"name": "prop2",
-													"value": "Bob"
-												}
-											],
-											"offer": {
-												"anoncreds": {
-													"schema_id": "schema:gSl0JkGIcmRif593Q6XYGsJndHGOzm1jWRFa-Lwrz9o",
-													"cred_def_id": "credential-definition:_p5hLM-uQa1zWnn3tBlSZjLHN3_jrHOq48HZg9x0WNU",
-													"key_correctness_proof": {
-														"c": "99492103123537767435780273140747875256790346132054146213963860002839562036500",
-														"xz_cap": "580439401883808314813871954452291264672809884147416670644868202601349938534100012582121009892201828623456062583253712122390217453057344836461080181231409709931412795314081026936945930855825367373487243407763891173044774127684739520982825154953842442273813308991169090527022468436144816388847602118294979269313055482643679093387752228933342461551523525381348315077261080667315083376665151670823724165412812789868725296452469727913099297098501657154305553628601670242915979173502981519452691532364945800381784094698957899207092852251635741642974685343076909543754528139524390330974942129175514270934196165227837447039632098505018004458669992226178741765564079908532417644335223001107373553800636",
-														"xr_cap": [
-															[
-																"prop2",
-																"995399175086393290156643492153533410460088296042299023071321712767423823125266832866393832677059827513393172141469698615988398481324616362988306901757713912635730675164176333343113543425145312139791479962174299119310631546985779208764729297940146997294517195382469523212546412350946365060108495261812541753519099438498374096964273878810634998095141423219246735648908552325440689746900928839923227716273385790878307688202350090032242160533886272557839856485554366696826060620961486642370355665610549033927229155523847761590023494696062955267842162962594983582064910274022357686360792641497125074245699228183099824304332072233714267713611371961270313585807822270849608871260298873632530881181868"
-															],
-															[
-																"prop1",
-																"1332724481340046129877312153176690921485462825381114334570976976911683740241735795674573565883450256485008453985793480391949571168596993894012183159420293482819645749037942541031221713594705004813170460963384907003707588246318592228064786935434434436493334335846541085008786621396358737393954898248156584956789603719162774096077144488775239706705659235938222621701852501004590177199881330248514156406621561858785958857377365259412279939255354717554715259409741463035067370342340375245558605525782229283165954317144433290958178245662795970871238028493809988026433044315609370187889271966194713168137139044017058936597616750741033931501545012220127203710939560438531093698046054460328575918119603"
-															],
-															[
-																"master_secret",
-																"555027667428826242052970636449944760049716355932181005994059994704109863707489157610003651613465020982803541959788424930381416736220275982020574537155052939117498439344162350344720165428803548470057405536121354129959126518248455145191069141936666484179865018445996249913288495893190150238690838395991946573833346853053011240922319143499605693196163287075552588023831726135219961691799755462617042764987540423466441420500952919498995496310058387923814988140775894040589217067406516222451334977386486085574931826246195042640621402064770528877288327158750876201208151309067281791780644173220251685733148275860559683101771901936515172131760435059336917112277256735606589048477347147443664213752574"
-															]
-														]
-													},
-													"nonce": "692456490106322710069916"
-												}
-											},
-											"request": {
-												"anoncreds": {
-													"entropy": "283559102751594275830315",
-													"cred_def_id": "credential-definition:_p5hLM-uQa1zWnn3tBlSZjLHN3_jrHOq48HZg9x0WNU",
-													"blinded_ms": {
-														"u": "58231223348966103131811162273993912136371812752782223808009746737780125568145868523057859605972791511440980139494915406073803687889151020231709198213752951834097534156853321419009300133041701988088059045538840265627332554454194121024426435019582352173715814900227749253559086664858523212471480396321468257159168804913614969187532210509785588812584841739263332234841113948381329216546405289807839367671066394371976377285491314443468087042916655417085254764424047492227119854758243993637314070997551720795324547265481480108567082864623565773819911308131308207210554182277214230022063294515760720713009700825428955532510",
-														"ur": null,
-														"hidden_attributes": [
-															"master_secret"
-														],
-														"committed_attributes": {}
-													},
-													"blinded_ms_correctness_proof": {
-														"c": "14842005166951621146114950228033228166587445948917220775188417180669817458071",
-														"v_dash_cap": "525886886600441444565563165744451574453581209783186527553278087235218067249143670252864427868001371270984533684519358843687605475581166282935142905703276466255860485038094631924069785904354326434488518339194078002719755861388964711768508348545543255979806148850295089036263281958934849704765108579167429147052286486914403929145073420962893811107068894159729549508196847548809587052009560288805123173353269086571490649648022184768357155256457950107309654761616752977676620176099125951088465313509009701650195907112862265146926434945766292668030673219665354811192934496571751927032511309995906445544597811901863475749538496709548405261395672321054035313087600543076125543620519913607917930629021139372239900295387614530",
-														"m_caps": {
-															"master_secret": "26403860841992559132025470865700367282768662423342071327016182400364926167433347005018624226591156120350434943733972616556764215219552899959288997912500104383298723878965850738210"
-														},
-														"r_caps": {}
-													},
-													"nonce": "539202924201893565376900"
-												}
-											},
-											"credential": {
-												"anoncreds": {
-													"schema_id": "schema:gSl0JkGIcmRif593Q6XYGsJndHGOzm1jWRFa-Lwrz9o",
-													"cred_def_id": "credential-definition:_p5hLM-uQa1zWnn3tBlSZjLHN3_jrHOq48HZg9x0WNU",
-													"values": {
-														"prop2": {
-															"raw": "Bob",
-															"encoded": "93006290325627508022776103386395994712401809437930957652111221015872244345185"
-														},
-														"prop1": {
-															"raw": "Alice",
-															"encoded": "27034640024117331033063128044004318218486816931520886405535659934417438781507"
-														}
-													},
-													"signature": {
-														"p_credential": {
-															"m_2": "2911715207125951422480156302046291340123870729973317007174252437265217048587",
-															"a": "11395635159250760503996843059477894862759042446759456478905609052258966666054297486499529657198356040094543149614125789362925680451864913383442428405747925006507714967572810462914901849679778018440516366649116468683963048348928719272415537003338969559562235424937950447758592924825449445925605210390900510823781990795216551732658029427081784108220873232530576542198769893886026016329571813137791144743390726969182823512920008254774588891824872946440672297966557771368796896826221080416623922702670373253252601697257131639339789773605316559189611430460668913621031924922363795873865565810614212399140440158978630736492",
-															"e": "259344723055062059907025491480697571938277889515152306249728583105665800713306759149981690559193987143012367913206299323899696942213235956742930090344543936461575196618473935962381",
-															"v": "8001814536142162607770363548208093772576030885155777393828891920810388269643639795739496611196183494954511428986568490597372615758581717334821354274023290392255038227577524325982981782454790052567586095566736421356705577874795304121932343609694749077725813635912948953884849597222055594720249473114949732531603732043206297827614841392072041631247914713339543298071003341199125553155575573253915872830335388346577731204615565550928758657918974242548635243688870260125103464458103572944515798752393429291619708048708181234777305612276265184799282497088401357918659516303709468557162638343709893397545583781671672656111029322715215691886249339655634731004758885743276863891497637192845057331073900220047078918373696507486114747681960422431667787893756346748792880297182146033915387360507174461962945213023817226802833132149"
-														},
-														"r_credential": null
-													},
-													"signature_correctness_proof": {
-														"se": "18071888966807930445969341878476115756105579849496822693675536304985965652940046036953323270875830549601629354090648450651925366597175546789259250284156036563261793522690459846803775756759065096398577328540423797501842695683583228588830053641258351279667129839173861484988969984108220499135535938554712154909596949678407619115337420038902354926030012219508589609561675458487780368202144228827896948708718677481449347040231630306565656593268126349021640222232240758703745752333545546720963799056251898068823571706878796745922121208045372883817285034174020297113979889276046972260648750830806544618009796203666715262922",
-														"c": "32233748970469592854527577130712976905395946986728509546042467955793436240507"
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Retrieve the format data associated with a credential exchange",
-				"tags": [
-					"DIDComm Credentials"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "credentialExchangeId",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/RecordId"
-						}
-					}
-				]
-			}
-		},
-		"/didcomm/credentials/propose-credential": {
-			"post": {
-				"operationId": "ProposeCredential",
-				"responses": {
-					"200": {
-						"description": "CredentialExchangeRecord",
-						"content": {
-							"application/json": {
-								"schema": {},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"credentials": [],
-											"type": "CredentialRecord",
-											"role": "holder",
-											"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
-											"createdAt": "2022-01-01T00:00:00.000Z",
-											"state": "offer-sent",
-											"connectionId": "ac6d0fdd-0db8-4f52-8a3d-de7ff8ddc14b",
-											"threadId": "82701488-b43c-4d7b-9244-4bb204a7ae26",
-											"credentialAttributes": [],
-											"protocolVersion": "v1"
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Initiate a new credential exchange as holder by sending a propose credential message\nto the connection with a specified connection id.",
-				"tags": [
-					"DIDComm Credentials"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/ProposeCredentialOptions"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/didcomm/credentials/{credentialExchangeId}/accept-proposal": {
-			"post": {
-				"operationId": "AcceptProposal",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"credentials": [],
-											"type": "CredentialRecord",
-											"role": "holder",
-											"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
-											"createdAt": "2022-01-01T00:00:00.000Z",
-											"state": "offer-sent",
-											"connectionId": "ac6d0fdd-0db8-4f52-8a3d-de7ff8ddc14b",
-											"threadId": "82701488-b43c-4d7b-9244-4bb204a7ae26",
-											"credentialAttributes": [],
-											"protocolVersion": "v1"
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Accept a credential proposal as issuer by sending an accept proposal message\nto the connection associated with the credential exchange record.",
-				"tags": [
-					"DIDComm Credentials"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "credentialExchangeId",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/RecordId"
-						}
-					}
-				],
-				"requestBody": {
-					"required": false,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/AcceptCredentialProposalOptions"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/didcomm/credentials/create-offer": {
-			"post": {
-				"operationId": "CreateOffer",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/DidCommCredentialsCreateOfferResponse"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"credentialExchange": {
-												"credentials": [],
-												"type": "CredentialRecord",
-												"role": "holder",
-												"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
-												"createdAt": "2022-01-01T00:00:00.000Z",
-												"state": "offer-sent",
-												"connectionId": "ac6d0fdd-0db8-4f52-8a3d-de7ff8ddc14b",
-												"threadId": "82701488-b43c-4d7b-9244-4bb204a7ae26",
-												"credentialAttributes": [],
-												"protocolVersion": "v1"
-											},
-											"message": {
-												"@id": "134b27f0-9366-4811-a36b-50bacfe57e61",
-												"@type": "https://didcomm.org/issue-credential/1.0/offer-credential"
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Initiate a new credential exchange as issuer by creating a credential offer\nwithout specifying a connection id",
-				"tags": [
-					"DIDComm Credentials"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/CreateOfferOptions"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/didcomm/credentials/offer-credential": {
-			"post": {
-				"operationId": "OfferCredential",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"credentials": [],
-											"type": "CredentialRecord",
-											"role": "holder",
-											"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
-											"createdAt": "2022-01-01T00:00:00.000Z",
-											"state": "offer-sent",
-											"connectionId": "ac6d0fdd-0db8-4f52-8a3d-de7ff8ddc14b",
-											"threadId": "82701488-b43c-4d7b-9244-4bb204a7ae26",
-											"credentialAttributes": [],
-											"protocolVersion": "v1"
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Initiate a new credential exchange as issuer by sending a offer credential message\nto the connection with the specified connection id.",
-				"tags": [
-					"DIDComm Credentials"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/OfferCredentialOptions"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/didcomm/credentials/{credentialExchangeId}/accept-offer": {
-			"post": {
-				"operationId": "AcceptOffer",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"credentials": [],
-											"type": "CredentialRecord",
-											"role": "holder",
-											"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
-											"createdAt": "2022-01-01T00:00:00.000Z",
-											"state": "offer-sent",
-											"connectionId": "ac6d0fdd-0db8-4f52-8a3d-de7ff8ddc14b",
-											"threadId": "82701488-b43c-4d7b-9244-4bb204a7ae26",
-											"credentialAttributes": [],
-											"protocolVersion": "v1"
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Accept a credential offer as holder by sending an accept offer message\nto the connection associated with the credential exchange record.",
-				"tags": [
-					"DIDComm Credentials"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "credentialExchangeId",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/RecordId"
-						}
-					}
-				],
-				"requestBody": {
-					"required": false,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/AcceptCredentialOfferOptions"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/didcomm/credentials/{credentialExchangeId}/accept-request": {
-			"post": {
-				"operationId": "AcceptRequest",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"credentials": [],
-											"type": "CredentialRecord",
-											"role": "holder",
-											"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
-											"createdAt": "2022-01-01T00:00:00.000Z",
-											"state": "offer-sent",
-											"connectionId": "ac6d0fdd-0db8-4f52-8a3d-de7ff8ddc14b",
-											"threadId": "82701488-b43c-4d7b-9244-4bb204a7ae26",
-											"credentialAttributes": [],
-											"protocolVersion": "v1"
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Accept a credential request as issuer by sending an accept request message\nto the connection associated with the credential exchange record.",
-				"tags": [
-					"DIDComm Credentials"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "credentialExchangeId",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/RecordId"
-						}
-					}
-				],
-				"requestBody": {
-					"required": false,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/AcceptCredentialRequestOptions"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/didcomm/credentials/{credentialExchangeId}/accept-credential": {
-			"post": {
-				"operationId": "AcceptCredential",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"credentials": [],
-											"type": "CredentialRecord",
-											"role": "holder",
-											"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
-											"createdAt": "2022-01-01T00:00:00.000Z",
-											"state": "offer-sent",
-											"connectionId": "ac6d0fdd-0db8-4f52-8a3d-de7ff8ddc14b",
-											"threadId": "82701488-b43c-4d7b-9244-4bb204a7ae26",
-											"credentialAttributes": [],
-											"protocolVersion": "v1"
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Accept a credential as holder by sending an accept credential message\nto the connection associated with the credential exchange record.",
-				"tags": [
-					"DIDComm Credentials"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "credentialExchangeId",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/RecordId"
-						}
-					}
-				]
-			}
-		},
-		"/didcomm/connections": {
-			"get": {
-				"operationId": "FindConnectionsByQuery",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"items": {
-										"$ref": "#/components/schemas/DidCommConnectionRecord"
-									},
-									"type": "array"
-								},
-								"examples": {
-									"Example 1": {
-										"value": [
-											{
-												"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
-												"type": "ConnectionRecord",
-												"createdAt": "2022-01-01T00:00:00.000Z",
-												"did": "did:peer:1zQmfQh1T3rSqarP2FZ37uKjdQHPKFdVyo2mGiAPHZ8Ep7hv",
-												"state": "invitation-sent",
-												"role": "responder",
-												"invitationDid": "did:peer:2.SeyJzIjoiaHR0cHM6Ly9kYTIzLTg5LTIwLTE2Mi0xNDYubmdyb2suaW8iLCJ0IjoiZGlkLWNvbW11bmljYXRpb24iLCJwcmlvcml0eSI6MCwicmVjaXBpZW50S2V5cyI6WyJkaWQ6a2V5Ono2TWtualg3U1lXRmdHMThCYkNEZHJnemhuQnA0UlhyOGVITHZxQ3FvRXllckxiTiN6Nk1rbmpYN1NZV0ZnRzE4QmJDRGRyZ3pobkJwNFJYcjhlSEx2cUNxb0V5ZXJMYk4iXSwiciI6W119",
-												"outOfBandId": "edbc89fe-785f-4774-a288-46012486881d"
-											}
-										]
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Find connection record by query",
-				"tags": [
-					"DIDComm Connections"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "query",
-						"name": "outOfBandId",
-						"required": false,
-						"schema": {
-							"$ref": "#/components/schemas/RecordId"
-						}
-					},
-					{
-						"in": "query",
-						"name": "alias",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"in": "query",
-						"name": "state",
-						"required": false,
-						"schema": {
-							"$ref": "#/components/schemas/DidExchangeState"
-						}
-					},
-					{
-						"in": "query",
-						"name": "did",
-						"required": false,
-						"schema": {
-							"$ref": "#/components/schemas/Did"
-						}
-					},
-					{
-						"in": "query",
-						"name": "theirDid",
-						"required": false,
-						"schema": {
-							"$ref": "#/components/schemas/Did"
-						}
-					},
-					{
-						"in": "query",
-						"name": "theirLabel",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/didcomm/connections/{connectionId}": {
-			"get": {
-				"operationId": "GetConnectionById",
-				"responses": {
-					"200": {
-						"description": "ConnectionRecord",
-						"content": {
-							"application/json": {
-								"schema": {},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
-											"type": "ConnectionRecord",
-											"createdAt": "2022-01-01T00:00:00.000Z",
-											"did": "did:peer:1zQmfQh1T3rSqarP2FZ37uKjdQHPKFdVyo2mGiAPHZ8Ep7hv",
-											"state": "invitation-sent",
-											"role": "responder",
-											"invitationDid": "did:peer:2.SeyJzIjoiaHR0cHM6Ly9kYTIzLTg5LTIwLTE2Mi0xNDYubmdyb2suaW8iLCJ0IjoiZGlkLWNvbW11bmljYXRpb24iLCJwcmlvcml0eSI6MCwicmVjaXBpZW50S2V5cyI6WyJkaWQ6a2V5Ono2TWtualg3U1lXRmdHMThCYkNEZHJnemhuQnA0UlhyOGVITHZxQ3FvRXllckxiTiN6Nk1rbmpYN1NZV0ZnRzE4QmJDRGRyZ3pobkJwNFJYcjhlSEx2cUNxb0V5ZXJMYk4iXSwiciI6W119",
-											"outOfBandId": "edbc89fe-785f-4774-a288-46012486881d"
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Retrieve connection record by connection id",
-				"tags": [
-					"DIDComm Connections"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"description": "Connection identifier",
-						"in": "path",
-						"name": "connectionId",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/RecordId"
-						}
-					}
-				]
-			},
-			"delete": {
-				"operationId": "DeleteConnection",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {}
-							}
-						}
-					}
-				},
-				"description": "Deletes a connection record from the connection repository.",
-				"tags": [
-					"DIDComm Connections"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"description": "Connection identifier",
-						"in": "path",
-						"name": "connectionId",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/RecordId"
-						}
-					}
-				]
-			}
-		},
-		"/didcomm/connections/{connectionId}/accept-request": {
-			"post": {
-				"operationId": "AcceptRequest",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
-											"type": "ConnectionRecord",
-											"createdAt": "2022-01-01T00:00:00.000Z",
-											"did": "did:peer:1zQmfQh1T3rSqarP2FZ37uKjdQHPKFdVyo2mGiAPHZ8Ep7hv",
-											"state": "invitation-sent",
-											"role": "responder",
-											"invitationDid": "did:peer:2.SeyJzIjoiaHR0cHM6Ly9kYTIzLTg5LTIwLTE2Mi0xNDYubmdyb2suaW8iLCJ0IjoiZGlkLWNvbW11bmljYXRpb24iLCJwcmlvcml0eSI6MCwicmVjaXBpZW50S2V5cyI6WyJkaWQ6a2V5Ono2TWtualg3U1lXRmdHMThCYkNEZHJnemhuQnA0UlhyOGVITHZxQ3FvRXllckxiTiN6Nk1rbmpYN1NZV0ZnRzE4QmJDRGRyZ3pobkJwNFJYcjhlSEx2cUNxb0V5ZXJMYk4iXSwiciI6W119",
-											"outOfBandId": "edbc89fe-785f-4774-a288-46012486881d"
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Accept a connection request as inviter by sending a connection response message\nfor the connection with the specified connection id.\n\nThis is not needed when auto accepting of connection is enabled.",
-				"tags": [
-					"DIDComm Connections"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "connectionId",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/RecordId"
-						}
-					}
-				]
-			}
-		},
-		"/didcomm/connections/{connectionId}/accept-response": {
-			"post": {
-				"operationId": "AcceptResponse",
-				"responses": {
-					"200": {
-						"description": "ConnectionRecord",
-						"content": {
-							"application/json": {
-								"schema": {},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
-											"type": "ConnectionRecord",
-											"createdAt": "2022-01-01T00:00:00.000Z",
-											"did": "did:peer:1zQmfQh1T3rSqarP2FZ37uKjdQHPKFdVyo2mGiAPHZ8Ep7hv",
-											"state": "invitation-sent",
-											"role": "responder",
-											"invitationDid": "did:peer:2.SeyJzIjoiaHR0cHM6Ly9kYTIzLTg5LTIwLTE2Mi0xNDYubmdyb2suaW8iLCJ0IjoiZGlkLWNvbW11bmljYXRpb24iLCJwcmlvcml0eSI6MCwicmVjaXBpZW50S2V5cyI6WyJkaWQ6a2V5Ono2TWtualg3U1lXRmdHMThCYkNEZHJnemhuQnA0UlhyOGVITHZxQ3FvRXllckxiTiN6Nk1rbmpYN1NZV0ZnRzE4QmJDRGRyZ3pobkJwNFJYcjhlSEx2cUNxb0V5ZXJMYk4iXSwiciI6W119",
-											"outOfBandId": "edbc89fe-785f-4774-a288-46012486881d"
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Accept a connection response as invitee by sending a trust ping message\nfor the connection with the specified connection id.\n\nThis is not needed when auto accepting of connection is enabled.",
-				"tags": [
-					"DIDComm Connections"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"description": "Connection identifier",
-						"in": "path",
-						"name": "connectionId",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/RecordId"
-						}
-					}
-				]
-			}
-		},
-		"/didcomm/basic-messages": {
-			"get": {
-				"operationId": "FindBasicMessagesByQuery",
-				"responses": {
-					"200": {
-						"description": "BasicMessageRecord[]",
-						"content": {
-							"application/json": {
-								"schema": {
-									"items": {
-										"$ref": "#/components/schemas/DidCommBasicMessageRecord"
-									},
-									"type": "array"
-								},
-								"examples": {
-									"Example 1": {
-										"value": [
-											{
-												"id": "74bcf865-1fdc-45b4-b517-9def02dfd25f",
-												"createdAt": "2022-08-18T08:38:40.216Z",
-												"type": "BasicMessageRecord",
-												"content": "Hello!",
-												"sentTime": "2022-08-18T08:38:40.216Z",
-												"connectionId": "2aecf74c-3073-4f98-9acb-92415d096834",
-												"role": "sender"
-											}
-										]
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Retrieve basic messages by connection id",
-				"tags": [
-					"DIDComm Basic Messages"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"description": "Connection identifier",
-						"in": "query",
-						"name": "connectionId",
-						"required": false,
-						"schema": {
-							"$ref": "#/components/schemas/RecordId"
-						}
-					},
-					{
-						"in": "query",
-						"name": "role",
-						"required": false,
-						"schema": {
-							"$ref": "#/components/schemas/BasicMessageRole"
-						}
-					},
-					{
-						"in": "query",
-						"name": "threadId",
-						"required": false,
-						"schema": {
-							"$ref": "#/components/schemas/ThreadId"
-						}
-					},
-					{
-						"in": "query",
-						"name": "parentThreadId",
-						"required": false,
-						"schema": {
-							"$ref": "#/components/schemas/ThreadId"
-						}
-					}
-				]
-			}
-		},
-		"/didcomm/basic-messages/send": {
-			"post": {
-				"operationId": "SendMessage",
-				"responses": {
-					"200": {
-						"description": "BasicMessageRecord",
-						"content": {
-							"application/json": {
-								"schema": {},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"id": "74bcf865-1fdc-45b4-b517-9def02dfd25f",
-											"createdAt": "2022-08-18T08:38:40.216Z",
-											"type": "BasicMessageRecord",
-											"content": "Hello!",
-											"sentTime": "2022-08-18T08:38:40.216Z",
-											"connectionId": "2aecf74c-3073-4f98-9acb-92415d096834",
-											"role": "sender"
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Send a basic message to a connection",
-				"tags": [
-					"DIDComm Basic Messages"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/DidCommBasicMessagesSendOptions"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/dids/{did}": {
-			"get": {
-				"operationId": "ResolveDid",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/DidResolveSuccessResponse"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"didDocument": {
-												"@context": [
-													"https://w3id.org/did/v1",
-													"https://w3id.org/security/suites/ed25519-2018/v1",
-													"https://w3id.org/security/suites/x25519-2019/v1"
-												],
-												"id": "did:key:z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL",
-												"verificationMethod": [
-													{
-														"id": "did:key:z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL#z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL",
-														"type": "Ed25519VerificationKey2018",
-														"controller": "did:key:z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL",
-														"publicKeyBase58": "6fioC1zcDPyPEL19pXRS2E4iJ46zH7xP6uSgAaPdwDrx"
-													}
-												],
-												"authentication": [
-													"did:key:z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL#z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL"
-												],
-												"assertionMethod": [
-													"did:key:z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL#z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL"
-												],
-												"capabilityInvocation": [
-													"did:key:z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL#z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL"
-												],
-												"capabilityDelegation": [
-													"did:key:z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL#z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL"
-												],
-												"keyAgreement": [
-													{
-														"id": "did:key:z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL#z6LSrdqo4M24WRDJj1h2hXxgtDTyzjjKCiyapYVgrhwZAySn",
-														"type": "X25519KeyAgreementKey2019",
-														"controller": "did:key:z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL",
-														"publicKeyBase58": "FxfdY3DCQxVZddKGAtSjZdFW9bCCW7oRwZn1NFJ2Tbg2"
-													}
-												]
-											},
-											"didDocumentMetadata": {},
-											"didResolutionMetadata": {
-												"contentType": "application/did+ld+json"
-											}
-										}
-									}
-								}
-							}
-						}
-					},
-					"404": {
-						"description": "Did not found",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/DidResolveFailedResponse"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"didDocument": null,
-											"didDocumentMetadata": {},
-											"didResolutionMetadata": {
-												"error": "notFound",
-												"message": "DID not found"
-											}
-										}
-									}
-								}
-							}
-						}
-					},
-					"500": {
-						"description": "Error resolving did",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/DidResolveFailedResponse"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"didDocument": null,
-											"didDocumentMetadata": {},
-											"didResolutionMetadata": {
-												"error": "notFound",
-												"message": "DID not found"
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Resolves did and returns did resolution result",
-				"tags": [
-					"Dids"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "did",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/dids/import": {
-			"post": {
-				"operationId": "ImportDid",
-				"responses": {
-					"201": {
-						"description": "Did imported successfully"
-					}
-				},
-				"description": "Import a did (with optional did document).\n\nIf no did document is provided, the did will be resolved to fetch the did document.",
-				"tags": [
-					"Dids"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/DidImportOptions"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/dids/create": {
-			"post": {
-				"operationId": "CreateDid",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/DidCreateFinishedResponse"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"didState": {
-												"did": "did:key:z6MkpGuzuD38tpgZKPfmLmmD8R6gihP9KJhuopMuVvfGzLmc",
-												"state": "finished",
-												"didDocument": {
-													"@context": [
-														"https://w3id.org/did/v1",
-														"https://w3id.org/security/suites/ed25519-2018/v1",
-														"https://w3id.org/security/suites/x25519-2019/v1"
-													],
-													"id": "did:key:z6MkpGuzuD38tpgZKPfmLmmD8R6gihP9KJhuopMuVvfGzLmc",
-													"verificationMethod": [
-														{
-															"id": "did:key:z6MkpGuzuD38tpgZKPfmLmmD8R6gihP9KJhuopMuVvfGzLmc#z6MkpGuzuD38tpgZKPfmLmmD8R6gihP9KJhuopMuVvfGzLmc",
-															"type": "Ed25519VerificationKey2018",
-															"controller": "did:key:z6MkpGuzuD38tpgZKPfmLmmD8R6gihP9KJhuopMuVvfGzLmc",
-															"publicKeyBase58": "ApexJxnhZHC6Ctq4fCoNHKYgu87HuRTZ7oSyfehG57zE"
-														}
-													],
-													"authentication": [
-														"did:key:z6MkpGuzuD38tpgZKPfmLmmD8R6gihP9KJhuopMuVvfGzLmc#z6MkpGuzuD38tpgZKPfmLmmD8R6gihP9KJhuopMuVvfGzLmc"
-													],
-													"assertionMethod": [
-														"did:key:z6MkpGuzuD38tpgZKPfmLmmD8R6gihP9KJhuopMuVvfGzLmc#z6MkpGuzuD38tpgZKPfmLmmD8R6gihP9KJhuopMuVvfGzLmc"
-													],
-													"keyAgreement": [
-														{
-															"id": "did:key:z6MkpGuzuD38tpgZKPfmLmmD8R6gihP9KJhuopMuVvfGzLmc#z6LSm5B4fB9NA55xB7PSeMYTMS9sf8uboJvyZBaDLLSZ7Ryd",
-															"type": "X25519KeyAgreementKey2019",
-															"controller": "did:key:z6MkpGuzuD38tpgZKPfmLmmD8R6gihP9KJhuopMuVvfGzLmc",
-															"publicKeyBase58": "APzu8sLW4cND5j1g7i2W2qwPozNV6hkpgCrXqso2Q4Cs"
-														}
-													],
-													"capabilityInvocation": [
-														"did:key:z6MkpGuzuD38tpgZKPfmLmmD8R6gihP9KJhuopMuVvfGzLmc#z6MkpGuzuD38tpgZKPfmLmmD8R6gihP9KJhuopMuVvfGzLmc"
-													],
-													"capabilityDelegation": [
-														"did:key:z6MkpGuzuD38tpgZKPfmLmmD8R6gihP9KJhuopMuVvfGzLmc#z6MkpGuzuD38tpgZKPfmLmmD8R6gihP9KJhuopMuVvfGzLmc"
-													]
-												}
-											},
-											"didDocumentMetadata": {},
-											"didRegistrationMetadata": {}
-										}
-									}
-								}
-							}
-						}
-					},
-					"202": {
-						"description": "Wait for action to complete",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/DidCreateWaitResponse"
-								},
-								"examples": {
-									"Example 1": {}
-								}
-							}
-						}
-					},
-					"500": {
-						"description": "Error creating did",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/DidCreateFailedResponse"
-								},
-								"examples": {
-									"Example 1": {}
-								}
-							}
-						}
-					}
-				},
-				"description": "Create a new did.",
-				"tags": [
-					"Dids"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/DidCreateOptions"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/anoncreds/schemas/{schemaId}": {
-			"get": {
-				"operationId": "GetSchemaById",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/AnonCredsGetSchemaSuccessResponse"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"resolutionMetadata": {},
-											"schemaMetadata": {},
-											"schemaId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv/anoncreds/v0/SCHEMA/schema-name/1.0",
-											"schema": {
-												"issuerId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv",
-												"name": "schema-name",
-												"version": "1.0",
-												"attrNames": [
-													"age"
-												]
-											}
-										}
-									}
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Invalid schemaId or unknown AnonCreds method provided",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/AnonCredsGetSchemaFailedResponse"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"resolutionMetadata": {
-												"error": "notFound",
-												"message": "Schema not found"
-											},
-											"schemaMetadata": {},
-											"schemaId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv/anoncreds/v0/SCHEMA/schema-name/1.0"
-										}
-									}
-								}
-							}
-						}
-					},
-					"404": {
-						"description": "Schema not found",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/AnonCredsGetSchemaFailedResponse"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"resolutionMetadata": {
-												"error": "notFound",
-												"message": "Schema not found"
-											},
-											"schemaMetadata": {},
-											"schemaId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv/anoncreds/v0/SCHEMA/schema-name/1.0"
-										}
-									}
-								}
-							}
-						}
-					},
-					"500": {
-						"description": "Unknown error retrieving schema",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/AnonCredsGetSchemaFailedResponse"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"resolutionMetadata": {
-												"error": "notFound",
-												"message": "Schema not found"
-											},
-											"schemaMetadata": {},
-											"schemaId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv/anoncreds/v0/SCHEMA/schema-name/1.0"
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Retrieve schema by schema id",
-				"tags": [
-					"AnonCreds"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "schemaId",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/AnonCredsSchemaId"
-						}
-					}
-				]
-			}
-		},
-		"/anoncreds/schemas": {
-			"post": {
-				"operationId": "RegisterSchema",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/AnonCredsRegisterSchemaSuccessResponse"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"registrationMetadata": {},
-											"schemaMetadata": {},
-											"schemaState": {
-												"state": "finished",
-												"schemaId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv/anoncreds/v0/SCHEMA/schema-name/1.0",
-												"schema": {
-													"issuerId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv",
-													"name": "schema-name",
-													"version": "1.0",
-													"attrNames": [
-														"string"
-													]
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					},
-					"202": {
-						"description": "Wait for action to complete",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/AnonCredsRegisterSchemaWaitResponse"
-								},
-								"examples": {
-									"Example 1": {}
-								}
-							}
-						}
-					},
-					"500": {
-						"description": "Unknown error registering schema",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/AnonCredsRegisterSchemaFailedResponse"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"registrationMetadata": {},
-											"schemaMetadata": {},
-											"schemaState": {
-												"state": "failed",
-												"reason": "Unknown error occurred while registering schema",
-												"schemaId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv/anoncreds/v0/SCHEMA/schema-name/1.0"
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Creates a new AnonCreds schema and registers the schema in the AnonCreds registry",
-				"tags": [
-					"AnonCreds"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/AnonCredsRegisterSchemaBody"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/anoncreds/credential-definitions/{credentialDefinitionId}": {
-			"get": {
-				"operationId": "GetCredentialDefinitionById",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/AnonCredsGetCredentialDefinitionSuccessResponse"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"resolutionMetadata": {},
-											"credentialDefinitionMetadata": {},
-											"credentialDefinitionId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv/anoncreds/v0/CLAIM_DEF/20/definition",
-											"credentialDefinition": {
-												"issuerId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv",
-												"schemaId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv/anoncreds/v0/SCHEMA/schema-name/1.0",
-												"type": "CL",
-												"tag": "definition",
-												"value": {
-													"primary": {
-														"n": "string",
-														"s": "string",
-														"r": {
-															"master_secret": "string",
-															"string": "string"
-														},
-														"rctxt": "string",
-														"z": "string"
-													},
-													"revocation": {
-														"g": "1 string",
-														"g_dash": "string",
-														"h": "string",
-														"h0": "string",
-														"h1": "string",
-														"h2": "string",
-														"htilde": "string",
-														"h_cap": "string",
-														"u": "string",
-														"pk": "string",
-														"y": "string"
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Invalid credentialDefinitionId or unknown AnonCreds method provided",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/AnonCredsGetCredentialDefinitionFailedResponse"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"resolutionMetadata": {
-												"error": "notFound",
-												"message": "CredentialDefinition not found"
-											},
-											"credentialDefinitionMetadata": {},
-											"credentialDefinitionId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv/anoncreds/v0/CLAIM_DEF/20/definition"
-										}
-									}
-								}
-							}
-						}
-					},
-					"404": {
-						"description": "CredentialDefinition not found",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/AnonCredsGetCredentialDefinitionFailedResponse"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"resolutionMetadata": {
-												"error": "notFound",
-												"message": "CredentialDefinition not found"
-											},
-											"credentialDefinitionMetadata": {},
-											"credentialDefinitionId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv/anoncreds/v0/CLAIM_DEF/20/definition"
-										}
-									}
-								}
-							}
-						}
-					},
-					"500": {
-						"description": "Unknown error retrieving credentialDefinition",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/AnonCredsGetCredentialDefinitionFailedResponse"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"resolutionMetadata": {
-												"error": "notFound",
-												"message": "CredentialDefinition not found"
-											},
-											"credentialDefinitionMetadata": {},
-											"credentialDefinitionId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv/anoncreds/v0/CLAIM_DEF/20/definition"
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Retrieve credentialDefinition by credentialDefinition id",
-				"tags": [
-					"AnonCreds"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "credentialDefinitionId",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/AnonCredsCredentialDefinitionId"
-						}
-					}
-				]
-			}
-		},
-		"/anoncreds/credential-definitions": {
-			"post": {
-				"operationId": "RegisterCredentialDefinition",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/AnonCredsRegisterCredentialDefinitionSuccessResponse"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"registrationMetadata": {},
-											"credentialDefinitionMetadata": {},
-											"credentialDefinitionState": {
-												"state": "finished",
-												"credentialDefinitionId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv/anoncreds/v0/SCHEMA/credentialDefinition-name/1.0",
-												"credentialDefinition": {
-													"issuerId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv",
-													"schemaId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv/anoncreds/v0/SCHEMA/schema-name/1.0",
-													"type": "CL",
-													"tag": "definition",
-													"value": {
-														"primary": {
-															"n": "string",
-															"s": "string",
-															"r": {
-																"master_secret": "string",
-																"string": "string"
-															},
-															"rctxt": "string",
-															"z": "string"
-														},
-														"revocation": {
-															"g": "1 string",
-															"g_dash": "string",
-															"h": "string",
-															"h0": "string",
-															"h1": "string",
-															"h2": "string",
-															"htilde": "string",
-															"h_cap": "string",
-															"u": "string",
-															"pk": "string",
-															"y": "string"
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					},
-					"202": {
-						"description": "Wait for action to complete",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/AnonCredsRegisterCredentialDefinitionWaitResponse"
-								},
-								"examples": {
-									"Example 1": {}
-								}
-							}
-						}
-					},
-					"500": {
-						"description": "Unknown error registering credentialDefinition",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/AnonCredsRegisterCredentialDefinitionFailedResponse"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"registrationMetadata": {},
-											"credentialDefinitionMetadata": {},
-											"credentialDefinitionState": {
-												"state": "failed",
-												"reason": "Unknown error occurred while registering credentialDefinition",
-												"credentialDefinitionId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv/anoncreds/v0/SCHEMA/credentialDefinition-name/1.0"
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Creates a new AnonCreds credentialDefinition and registers the credentialDefinition in the AnonCreds registry",
-				"tags": [
-					"AnonCreds"
-				],
-				"security": [
-					{
-						"tenants": [
-							"tenant"
-						]
-					}
-				],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/AnonCredsRegisterCredentialDefinitionBody"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/agent": {
-			"get": {
-				"operationId": "GetAgentInfo",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/AgentInfo"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"config": {
-												"label": "Example Agent",
-												"endpoints": [
-													"http://localhost:3000"
-												]
-											},
-											"isInitialized": true
-										}
-									}
-								}
-							}
-						}
-					}
-				},
-				"description": "Retrieve basic agent information",
-				"tags": [
-					"Agent"
-				],
-				"security": [
-					{
-						"tenants": [
-							"default"
-						]
-					}
-				],
-				"parameters": []
-			}
-		}
-	},
-	"servers": [
-		{
-			"url": "/"
-		}
-	]
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Credo REST API",
+    "version": "0.9.5",
+    "description": "Rest API for using Credo over HTTP",
+    "license": {
+      "name": "Apache-2.0"
+    },
+    "contact": {}
+  },
+  "paths": {
+    "/tenants": {
+      "post": {
+        "operationId": "CreateTenant",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TenantRecord"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "config": {
+                        "label": "Example"
+                      },
+                      "createdAt": "2022-08-18T08:38:40.216Z",
+                      "updatedAt": "2022-08-18T08:38:40.216Z",
+                      "id": "27137142-2e5b-471b-a427-7d5d3fd6d39b",
+                      "storageVersion": "0.5",
+                      "type": "TenantRecord"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "create new tenant",
+        "tags": [
+          "Tenants"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TenantsCreateOptions"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "GetTenantsByQuery",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/TenantRecord"
+                  },
+                  "type": "array"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": [
+                      {
+                        "config": {
+                          "label": "Example"
+                        },
+                        "createdAt": "2022-08-18T08:38:40.216Z",
+                        "updatedAt": "2022-08-18T08:38:40.216Z",
+                        "id": "27137142-2e5b-471b-a427-7d5d3fd6d39b",
+                        "storageVersion": "0.5",
+                        "type": "TenantRecord"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "get tenants by query",
+        "tags": [
+          "Tenants"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "label",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "storageVersion",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      }
+    },
+    "/tenants/{tenantId}": {
+      "get": {
+        "operationId": "GetTenant",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TenantRecord"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "config": {
+                        "label": "Example"
+                      },
+                      "createdAt": "2022-08-18T08:38:40.216Z",
+                      "updatedAt": "2022-08-18T08:38:40.216Z",
+                      "id": "27137142-2e5b-471b-a427-7d5d3fd6d39b",
+                      "storageVersion": "0.5",
+                      "type": "TenantRecord"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "get tenant by id",
+        "tags": [
+          "Tenants"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenantId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      },
+      "put": {
+        "operationId": "UpdateTenant",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TenantRecord"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "config": {
+                        "label": "Example"
+                      },
+                      "createdAt": "2022-08-18T08:38:40.216Z",
+                      "updatedAt": "2022-08-18T08:38:40.216Z",
+                      "id": "27137142-2e5b-471b-a427-7d5d3fd6d39b",
+                      "storageVersion": "0.5",
+                      "type": "TenantRecord"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "update tenant by id.\n\nNOTE: this does not overwrite the entire tenant record, only the properties that are passed in the body.\nIf you want to unset an non-required value, you can pass `null`.",
+        "tags": [
+          "Tenants"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenantId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TenantsUpdateOptions"
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "DeleteTenant",
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        },
+        "description": "delete tenant by id",
+        "tags": [
+          "Tenants"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenantId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      }
+    },
+    "/openid4vc/verifiers": {
+      "post": {
+        "operationId": "CreateVerifier",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpenId4VcVerifierRecord"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "id": "a3327f09-1d48-48a5-89b1-6678a33c0539",
+                      "createdAt": "2024-03-29T15:26:58.347Z",
+                      "updatedAt": "2024-03-29T15:26:58.347Z",
+                      "type": "OpenId4VcVerifierRecord",
+                      "publicVerifierId": "0aa796ef-d79d-457f-a4b9-40b99e47fef2"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Create a new OpenID4VC Verifier",
+        "tags": [
+          "OpenID4VC Verifiers"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OpenId4VcVerifiersCreateOptions"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "GetVerifiersByQuery",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/OpenId4VcVerifierRecord"
+                  },
+                  "type": "array"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": [
+                      {
+                        "id": "a3327f09-1d48-48a5-89b1-6678a33c0539",
+                        "createdAt": "2024-03-29T15:26:58.347Z",
+                        "updatedAt": "2024-03-29T15:26:58.347Z",
+                        "type": "OpenId4VcVerifierRecord",
+                        "publicVerifierId": "0aa796ef-d79d-457f-a4b9-40b99e47fef2"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Get OpenID4VC verifiers by query",
+        "tags": [
+          "OpenID4VC Verifiers"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "publicVerifierId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      }
+    },
+    "/openid4vc/verifiers/{verifierId}": {
+      "get": {
+        "operationId": "GetVerifier",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpenId4VcVerifierRecord"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "id": "a3327f09-1d48-48a5-89b1-6678a33c0539",
+                      "createdAt": "2024-03-29T15:26:58.347Z",
+                      "updatedAt": "2024-03-29T15:26:58.347Z",
+                      "type": "OpenId4VcVerifierRecord",
+                      "publicVerifierId": "0aa796ef-d79d-457f-a4b9-40b99e47fef2"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Get an OpenID4VC verifier by id",
+        "tags": [
+          "OpenID4VC Verifiers"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "verifierId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteVerifier",
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        },
+        "description": "Delete an OpenID4VC verifier by id",
+        "tags": [
+          "OpenID4VC Verifiers"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "verifierId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      }
+    },
+    "/openid4vc/verifiers/sessions/create-request": {
+      "post": {
+        "operationId": "CreateRequest",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpenId4VcVerificationSessionsCreateRequestResponse"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "verificationSession": {
+                        "id": "9cde9070-23c9-4e51-b810-e929a0298cbb",
+                        "createdAt": "2024-03-29T17:54:34.890Z",
+                        "updatedAt": "2024-03-29T17:54:34.890Z",
+                        "type": "OpenId4VcVerificationSessionRecord",
+                        "publicVerifierId": "a868257d-7149-4d4d-a52c-78f3197ee538",
+                        "authorizationRequestJwt": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa2dWaXdmc3RDTDFMOWk4dGdzZEFZRXU1QTYyVzVtQTlEY21TeWdWVlZMRnVVI3o2TWtnVml3ZnN0Q0wxTDlpOHRnc2RBWUV1NUE2Mlc1bUE5RGNtU3lnVlZWTEZ1VSIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE3MTE3MzgxNjEsImV4cCI6MTcxMTczODI4MSwicmVzcG9uc2VfdHlwZSI6ImlkX3Rva2VuIHZwX3Rva2VuIiwic2NvcGUiOiJvcGVuaWQiLCJjbGllbnRfaWQiOiJkaWQ6a2V5Ono2TWtnVml3ZnN0Q0wxTDlpOHRnc2RBWUV1NUE2Mlc1bUE5RGNtU3lnVlZWTEZ1VSIsInJlZGlyZWN0X3VyaSI6Imh0dHBzOi8vZDBjZS0yMTctMTIzLTE4LTI2Lm5ncm9rLWZyZWUuYXBwL3Npb3AvMWFiMzBjMGUtMWFkYi00ZjAxLTkwZTgtY2ZkNDI1YzBhMzExL2F1dGhvcml6ZSIsInJlc3BvbnNlX21vZGUiOiJwb3N0Iiwibm9uY2UiOiIxMDQwMzQ1NjY0MDI1NTEzODE3MzgyNjk4Iiwic3RhdGUiOiI0MzQ3NTE3MjgzNDM2ODc1NzYzODQ1MTAiLCJjbGllbnRfbWV0YWRhdGEiOnsiaWRfdG9rZW5fc2lnbmluZ19hbGdfdmFsdWVzX3N1cHBvcnRlZCI6WyJFZERTQSIsIkVTMjU2IiwiRVMyNTZLIl0sInJlc3BvbnNlX3R5cGVzX3N1cHBvcnRlZCI6WyJ2cF90b2tlbiIsImlkX3Rva2VuIl0sInN1YmplY3Rfc3ludGF4X3R5cGVzX3N1cHBvcnRlZCI6WyJkaWQ6d2ViIiwiZGlkOmtleSIsImRpZDpqd2siXSwidnBfZm9ybWF0cyI6eyJqd3RfdmMiOnsiYWxnIjpbIkVkRFNBIiwiRVMyNTYiLCJFUzI1NksiXX0sImp3dF92Y19qc29uIjp7ImFsZyI6WyJFZERTQSIsIkVTMjU2IiwiRVMyNTZLIl19LCJqd3RfdnAiOnsiYWxnIjpbIkVkRFNBIiwiRVMyNTYiLCJFUzI1NksiXX0sImxkcF92YyI6eyJwcm9vZl90eXBlIjpbIkVkMjU1MTlTaWduYXR1cmUyMDE4Il19LCJsZHBfdnAiOnsicHJvb2ZfdHlwZSI6WyJFZDI1NTE5U2lnbmF0dXJlMjAxOCJdfSwidmMrc2Qtand0Ijp7ImtiX2p3dF9hbGdfdmFsdWVzIjpbIkVkRFNBIiwiRVMyNTYiLCJFUzI1NksiXSwic2Rfand0X2FsZ192YWx1ZXMiOlsiRWREU0EiLCJFUzI1NiIsIkVTMjU2SyJdfX0sImNsaWVudF9pZCI6ImRpZDprZXk6ejZNa2dWaXdmc3RDTDFMOWk4dGdzZEFZRXU1QTYyVzVtQTlEY21TeWdWVlZMRnVVIn0sInByZXNlbnRhdGlvbl9kZWZpbml0aW9uIjp7ImlkIjoiNzM3OTdiMGMtZGFlNi00NmE3LTk3MDAtNzg1MDg1NWZlZTIyIiwibmFtZSI6IkV4YW1wbGUgUHJlc2VudGF0aW9uIERlZmluaXRpb24iLCJpbnB1dF9kZXNjcmlwdG9ycyI6W3siaWQiOiI2NDEyNTc0Mi04YjZjLTQyMmUtODJjZC0xYmViNTEyM2VlOGYiLCJjb25zdHJhaW50cyI6eyJsaW1pdF9kaXNjbG9zdXJlIjoicmVxdWlyZWQiLCJmaWVsZHMiOlt7InBhdGgiOlsiJC5hZ2Uub3Zlcl8xOCJdLCJmaWx0ZXIiOnsidHlwZSI6ImJvb2xlYW4ifX1dfSwibmFtZSI6IlJlcXVlc3RlZCBTZCBKd3QgRXhhbXBsZSBDcmVkZW50aWFsIiwicHVycG9zZSI6IlRvIHByb3ZpZGUgYW4gZXhhbXBsZSBvZiByZXF1ZXN0aW5nIGEgY3JlZGVudGlhbCJ9XX0sIm5iZiI6MTcxMTczODE2MSwianRpIjoiNThlNTA2MzgtOGU0ZS00NTQ5LWFmNDktMzQzNDI4N2IyODJlIiwiaXNzIjoiZGlkOmtleTp6Nk1rZ1Zpd2ZzdENMMUw5aTh0Z3NkQVlFdTVBNjJXNW1BOURjbVN5Z1ZWVkxGdVUiLCJzdWIiOiJkaWQ6a2V5Ono2TWtnVml3ZnN0Q0wxTDlpOHRnc2RBWUV1NUE2Mlc1bUE5RGNtU3lnVlZWTEZ1VSJ9.zAndpciC3rYi6tmItYi8P9uGqkId_3TNEgJHeFeBA1fWgJ4aY8Y2a5RmeGHl4-fXMV8Ff1-tpR86z-6v7pkvDQ",
+                        "authorizationRequestUri": "https://d0ce-217-123-18-26.ngrok-free.app/siop/1ab30c0e-1adb-4f01-90e8-cfd425c0a311/authorization-requests/365d0d2f-e62b-4596-92cd-8c4baa7047d6",
+                        "state": "RequestUriRetrieved"
+                      },
+                      "authorizationRequest": "openid://?request_uri=https%3A%2F%2Fexample.com%2Fsiop%2F6b293c23-d55a-4c6a-8c6a-877d69a70b4d%2Fauthorization-requests%2F6e7dce29-9d6a-4a13-a820-6a19b2ea9945"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Create an OpenID4VC verification session by creating a authorization request",
+        "tags": [
+          "OpenID4VC Verification Sessions"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OpenId4VcVerificationSessionsCreateRequestOptions"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openid4vc/verifiers/sessions/{verificationSessionId}/verified-authorization-response": {
+      "get": {
+        "operationId": "GetVerifiedAuthorizationResponse",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpenId4VcVerificationSessionsGetVerifiedAuthorizationResponseResponse"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "idToken": {
+                        "payload": {
+                          "iat": 1711678207,
+                          "exp": 1711744207,
+                          "iss": "did:jwk:eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6InRZSkY5a0NCeXpJT1RWc1FOclhrRTlQZW92eEJrcUNuejBQN3Q5Y2poblUiLCJ5IjoiZnlIckh3U21PSGlfa2dDdGM2RWF4ckpZQ2R1WWRQbm5VTGJ5RVBPTGpabyJ9",
+                          "aud": "did:key:z6MkgViwfstCL1L9i8tgsdAYEu5A62W5mA9DcmSygVVVLFuU",
+                          "sub": "did:jwk:eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6InRZSkY5a0NCeXpJT1RWc1FOclhrRTlQZW92eEJrcUNuejBQN3Q5Y2poblUiLCJ5IjoiZnlIckh3U21PSGlfa2dDdGM2RWF4ckpZQ2R1WWRQbm5VTGJ5RVBPTGpabyJ9",
+                          "nonce": "1040345664025513817382698",
+                          "state": "434751728343687576384510"
+                        }
+                      },
+                      "presentationExchange": {
+                        "definition": {
+                          "id": "73797b0c-dae6-46a7-9700-7850855fee22",
+                          "name": "Example Presentation Definition",
+                          "input_descriptors": [
+                            {
+                              "id": "64125742-8b6c-422e-82cd-1beb5123ee8f",
+                              "constraints": {
+                                "limit_disclosure": "required",
+                                "fields": [
+                                  {
+                                    "path": [
+                                      "$.age.over_18"
+                                    ],
+                                    "filter": {
+                                      "type": "boolean"
+                                    }
+                                  }
+                                ]
+                              },
+                              "name": "Requested Sd Jwt Example Credential",
+                              "purpose": "To provide an example of requesting a credential"
+                            }
+                          ]
+                        },
+                        "presentations": [
+                          {
+                            "format": "vc+sd-jwt",
+                            "encoded": "eyJhbGciOiJFZERTQSIsInR5cCI6InZjK3NkLWp3dCIsImtpZCI6...",
+                            "vcPayload": {
+                              "first_name": "John",
+                              "last_name": "Doe",
+                              "age": {
+                                "over_18": true
+                              },
+                              "vct": "https://example.com/vct#ExampleCredential",
+                              "cnf": {
+                                "kid": "did:jwk:eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6InRZSkY5a0NCeXpJT1RWc1FOclhrRTlQZW92eEJrcUNuejBQN3Q5Y2poblUiLCJ5IjoiZnlIckh3U21PSGlfa2dDdGM2RWF4ckpZQ2R1WWRQbm5VTGJ5RVBPTGpabyJ9#0"
+                              },
+                              "iss": "did:key:z6MkgViwfstCL1L9i8tgsdAYEu5A62W5mA9DcmSygVVVLFuU",
+                              "iat": 1711737824
+                            },
+                            "signedPayload": {
+                              "first_name": "John",
+                              "last_name": "Doe",
+                              "age": {
+                                "_sd": [
+                                  "7-KKV_C6uNhINhW1_6zdv9pHGeoSErL0kXQLRLGRkOs",
+                                  "J-HR5dUgq0__vzlSknqLhZIgyfdqoFGz1IiWiUUjHy8",
+                                  "Y5fMNOwiZgzQFD3XtjowpRYEr0Rw6YU7ZwDimGV3b60"
+                                ]
+                              },
+                              "vct": "https://example.com/vct#ExampleCredential",
+                              "cnf": {
+                                "kid": "did:jwk:eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6InRZSkY5a0NCeXpJT1RWc1FOclhrRTlQZW92eEJrcUNuejBQN3Q5Y2poblUiLCJ5IjoiZnlIckh3U21PSGlfa2dDdGM2RWF4ckpZQ2R1WWRQbm5VTGJ5RVBPTGpabyJ9#0"
+                              },
+                              "iss": "did:key:z6MkgViwfstCL1L9i8tgsdAYEu5A62W5mA9DcmSygVVVLFuU",
+                              "iat": 1711737824,
+                              "_sd_alg": "sha-256"
+                            },
+                            "header": {
+                              "alg": "EdDSA",
+                              "typ": "vc+sd-jwt",
+                              "kid": "#z6MkgViwfstCL1L9i8tgsdAYEu5A62W5mA9DcmSygVVVLFuU"
+                            }
+                          }
+                        ],
+                        "submission": {
+                          "id": "tmCha4zQKAZF-aBTCT8W3",
+                          "definition_id": "73797b0c-dae6-46a7-9700-7850855fee22",
+                          "descriptor_map": [
+                            {
+                              "id": "64125742-8b6c-422e-82cd-1beb5123ee8f",
+                              "format": "vc+sd-jwt",
+                              "path": "$"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Get the verified authorization response data for a OpenID4VC verification session.\n\nThis endpoint can only be called for verification sessions where the state is `ResponseVerified`.",
+        "tags": [
+          "OpenID4VC Verification Sessions"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "verificationSessionId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      }
+    },
+    "/openid4vc/verifiers/sessions": {
+      "get": {
+        "operationId": "GetVerificationSessionsByQuery",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/OpenId4VcVerificationSessionRecord"
+                  },
+                  "type": "array"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": [
+                      {
+                        "id": "9cde9070-23c9-4e51-b810-e929a0298cbb",
+                        "createdAt": "2024-03-29T17:54:34.890Z",
+                        "updatedAt": "2024-03-29T17:54:34.890Z",
+                        "type": "OpenId4VcVerificationSessionRecord",
+                        "publicVerifierId": "a868257d-7149-4d4d-a52c-78f3197ee538",
+                        "authorizationRequestJwt": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa2dWaXdmc3RDTDFMOWk4dGdzZEFZRXU1QTYyVzVtQTlEY21TeWdWVlZMRnVVI3o2TWtnVml3ZnN0Q0wxTDlpOHRnc2RBWUV1NUE2Mlc1bUE5RGNtU3lnVlZWTEZ1VSIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE3MTE3MzgxNjEsImV4cCI6MTcxMTczODI4MSwicmVzcG9uc2VfdHlwZSI6ImlkX3Rva2VuIHZwX3Rva2VuIiwic2NvcGUiOiJvcGVuaWQiLCJjbGllbnRfaWQiOiJkaWQ6a2V5Ono2TWtnVml3ZnN0Q0wxTDlpOHRnc2RBWUV1NUE2Mlc1bUE5RGNtU3lnVlZWTEZ1VSIsInJlZGlyZWN0X3VyaSI6Imh0dHBzOi8vZDBjZS0yMTctMTIzLTE4LTI2Lm5ncm9rLWZyZWUuYXBwL3Npb3AvMWFiMzBjMGUtMWFkYi00ZjAxLTkwZTgtY2ZkNDI1YzBhMzExL2F1dGhvcml6ZSIsInJlc3BvbnNlX21vZGUiOiJwb3N0Iiwibm9uY2UiOiIxMDQwMzQ1NjY0MDI1NTEzODE3MzgyNjk4Iiwic3RhdGUiOiI0MzQ3NTE3MjgzNDM2ODc1NzYzODQ1MTAiLCJjbGllbnRfbWV0YWRhdGEiOnsiaWRfdG9rZW5fc2lnbmluZ19hbGdfdmFsdWVzX3N1cHBvcnRlZCI6WyJFZERTQSIsIkVTMjU2IiwiRVMyNTZLIl0sInJlc3BvbnNlX3R5cGVzX3N1cHBvcnRlZCI6WyJ2cF90b2tlbiIsImlkX3Rva2VuIl0sInN1YmplY3Rfc3ludGF4X3R5cGVzX3N1cHBvcnRlZCI6WyJkaWQ6d2ViIiwiZGlkOmtleSIsImRpZDpqd2siXSwidnBfZm9ybWF0cyI6eyJqd3RfdmMiOnsiYWxnIjpbIkVkRFNBIiwiRVMyNTYiLCJFUzI1NksiXX0sImp3dF92Y19qc29uIjp7ImFsZyI6WyJFZERTQSIsIkVTMjU2IiwiRVMyNTZLIl19LCJqd3RfdnAiOnsiYWxnIjpbIkVkRFNBIiwiRVMyNTYiLCJFUzI1NksiXX0sImxkcF92YyI6eyJwcm9vZl90eXBlIjpbIkVkMjU1MTlTaWduYXR1cmUyMDE4Il19LCJsZHBfdnAiOnsicHJvb2ZfdHlwZSI6WyJFZDI1NTE5U2lnbmF0dXJlMjAxOCJdfSwidmMrc2Qtand0Ijp7ImtiX2p3dF9hbGdfdmFsdWVzIjpbIkVkRFNBIiwiRVMyNTYiLCJFUzI1NksiXSwic2Rfand0X2FsZ192YWx1ZXMiOlsiRWREU0EiLCJFUzI1NiIsIkVTMjU2SyJdfX0sImNsaWVudF9pZCI6ImRpZDprZXk6ejZNa2dWaXdmc3RDTDFMOWk4dGdzZEFZRXU1QTYyVzVtQTlEY21TeWdWVlZMRnVVIn0sInByZXNlbnRhdGlvbl9kZWZpbml0aW9uIjp7ImlkIjoiNzM3OTdiMGMtZGFlNi00NmE3LTk3MDAtNzg1MDg1NWZlZTIyIiwibmFtZSI6IkV4YW1wbGUgUHJlc2VudGF0aW9uIERlZmluaXRpb24iLCJpbnB1dF9kZXNjcmlwdG9ycyI6W3siaWQiOiI2NDEyNTc0Mi04YjZjLTQyMmUtODJjZC0xYmViNTEyM2VlOGYiLCJjb25zdHJhaW50cyI6eyJsaW1pdF9kaXNjbG9zdXJlIjoicmVxdWlyZWQiLCJmaWVsZHMiOlt7InBhdGgiOlsiJC5hZ2Uub3Zlcl8xOCJdLCJmaWx0ZXIiOnsidHlwZSI6ImJvb2xlYW4ifX1dfSwibmFtZSI6IlJlcXVlc3RlZCBTZCBKd3QgRXhhbXBsZSBDcmVkZW50aWFsIiwicHVycG9zZSI6IlRvIHByb3ZpZGUgYW4gZXhhbXBsZSBvZiByZXF1ZXN0aW5nIGEgY3JlZGVudGlhbCJ9XX0sIm5iZiI6MTcxMTczODE2MSwianRpIjoiNThlNTA2MzgtOGU0ZS00NTQ5LWFmNDktMzQzNDI4N2IyODJlIiwiaXNzIjoiZGlkOmtleTp6Nk1rZ1Zpd2ZzdENMMUw5aTh0Z3NkQVlFdTVBNjJXNW1BOURjbVN5Z1ZWVkxGdVUiLCJzdWIiOiJkaWQ6a2V5Ono2TWtnVml3ZnN0Q0wxTDlpOHRnc2RBWUV1NUE2Mlc1bUE5RGNtU3lnVlZWTEZ1VSJ9.zAndpciC3rYi6tmItYi8P9uGqkId_3TNEgJHeFeBA1fWgJ4aY8Y2a5RmeGHl4-fXMV8Ff1-tpR86z-6v7pkvDQ",
+                        "authorizationRequestUri": "https://d0ce-217-123-18-26.ngrok-free.app/siop/1ab30c0e-1adb-4f01-90e8-cfd425c0a311/authorization-requests/365d0d2f-e62b-4596-92cd-8c4baa7047d6",
+                        "state": "RequestUriRetrieved"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Find all OpenID4VC verification sessions by query",
+        "tags": [
+          "OpenID4VC Verification Sessions"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "nonce",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "publicVerifierId",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/PublicIssuerId"
+            }
+          },
+          {
+            "in": "query",
+            "name": "payloadState",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "state",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/OpenId4VcVerificationSessionState"
+            }
+          },
+          {
+            "in": "query",
+            "name": "authorizationRequestUri",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      }
+    },
+    "/openid4vc/verifiers/sessions/{verificationSessionId}": {
+      "get": {
+        "operationId": "GetVerificationSession",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpenId4VcVerificationSessionRecord"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "id": "9cde9070-23c9-4e51-b810-e929a0298cbb",
+                      "createdAt": "2024-03-29T17:54:34.890Z",
+                      "updatedAt": "2024-03-29T17:54:34.890Z",
+                      "type": "OpenId4VcVerificationSessionRecord",
+                      "publicVerifierId": "a868257d-7149-4d4d-a52c-78f3197ee538",
+                      "authorizationRequestJwt": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa2dWaXdmc3RDTDFMOWk4dGdzZEFZRXU1QTYyVzVtQTlEY21TeWdWVlZMRnVVI3o2TWtnVml3ZnN0Q0wxTDlpOHRnc2RBWUV1NUE2Mlc1bUE5RGNtU3lnVlZWTEZ1VSIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE3MTE3MzgxNjEsImV4cCI6MTcxMTczODI4MSwicmVzcG9uc2VfdHlwZSI6ImlkX3Rva2VuIHZwX3Rva2VuIiwic2NvcGUiOiJvcGVuaWQiLCJjbGllbnRfaWQiOiJkaWQ6a2V5Ono2TWtnVml3ZnN0Q0wxTDlpOHRnc2RBWUV1NUE2Mlc1bUE5RGNtU3lnVlZWTEZ1VSIsInJlZGlyZWN0X3VyaSI6Imh0dHBzOi8vZDBjZS0yMTctMTIzLTE4LTI2Lm5ncm9rLWZyZWUuYXBwL3Npb3AvMWFiMzBjMGUtMWFkYi00ZjAxLTkwZTgtY2ZkNDI1YzBhMzExL2F1dGhvcml6ZSIsInJlc3BvbnNlX21vZGUiOiJwb3N0Iiwibm9uY2UiOiIxMDQwMzQ1NjY0MDI1NTEzODE3MzgyNjk4Iiwic3RhdGUiOiI0MzQ3NTE3MjgzNDM2ODc1NzYzODQ1MTAiLCJjbGllbnRfbWV0YWRhdGEiOnsiaWRfdG9rZW5fc2lnbmluZ19hbGdfdmFsdWVzX3N1cHBvcnRlZCI6WyJFZERTQSIsIkVTMjU2IiwiRVMyNTZLIl0sInJlc3BvbnNlX3R5cGVzX3N1cHBvcnRlZCI6WyJ2cF90b2tlbiIsImlkX3Rva2VuIl0sInN1YmplY3Rfc3ludGF4X3R5cGVzX3N1cHBvcnRlZCI6WyJkaWQ6d2ViIiwiZGlkOmtleSIsImRpZDpqd2siXSwidnBfZm9ybWF0cyI6eyJqd3RfdmMiOnsiYWxnIjpbIkVkRFNBIiwiRVMyNTYiLCJFUzI1NksiXX0sImp3dF92Y19qc29uIjp7ImFsZyI6WyJFZERTQSIsIkVTMjU2IiwiRVMyNTZLIl19LCJqd3RfdnAiOnsiYWxnIjpbIkVkRFNBIiwiRVMyNTYiLCJFUzI1NksiXX0sImxkcF92YyI6eyJwcm9vZl90eXBlIjpbIkVkMjU1MTlTaWduYXR1cmUyMDE4Il19LCJsZHBfdnAiOnsicHJvb2ZfdHlwZSI6WyJFZDI1NTE5U2lnbmF0dXJlMjAxOCJdfSwidmMrc2Qtand0Ijp7ImtiX2p3dF9hbGdfdmFsdWVzIjpbIkVkRFNBIiwiRVMyNTYiLCJFUzI1NksiXSwic2Rfand0X2FsZ192YWx1ZXMiOlsiRWREU0EiLCJFUzI1NiIsIkVTMjU2SyJdfX0sImNsaWVudF9pZCI6ImRpZDprZXk6ejZNa2dWaXdmc3RDTDFMOWk4dGdzZEFZRXU1QTYyVzVtQTlEY21TeWdWVlZMRnVVIn0sInByZXNlbnRhdGlvbl9kZWZpbml0aW9uIjp7ImlkIjoiNzM3OTdiMGMtZGFlNi00NmE3LTk3MDAtNzg1MDg1NWZlZTIyIiwibmFtZSI6IkV4YW1wbGUgUHJlc2VudGF0aW9uIERlZmluaXRpb24iLCJpbnB1dF9kZXNjcmlwdG9ycyI6W3siaWQiOiI2NDEyNTc0Mi04YjZjLTQyMmUtODJjZC0xYmViNTEyM2VlOGYiLCJjb25zdHJhaW50cyI6eyJsaW1pdF9kaXNjbG9zdXJlIjoicmVxdWlyZWQiLCJmaWVsZHMiOlt7InBhdGgiOlsiJC5hZ2Uub3Zlcl8xOCJdLCJmaWx0ZXIiOnsidHlwZSI6ImJvb2xlYW4ifX1dfSwibmFtZSI6IlJlcXVlc3RlZCBTZCBKd3QgRXhhbXBsZSBDcmVkZW50aWFsIiwicHVycG9zZSI6IlRvIHByb3ZpZGUgYW4gZXhhbXBsZSBvZiByZXF1ZXN0aW5nIGEgY3JlZGVudGlhbCJ9XX0sIm5iZiI6MTcxMTczODE2MSwianRpIjoiNThlNTA2MzgtOGU0ZS00NTQ5LWFmNDktMzQzNDI4N2IyODJlIiwiaXNzIjoiZGlkOmtleTp6Nk1rZ1Zpd2ZzdENMMUw5aTh0Z3NkQVlFdTVBNjJXNW1BOURjbVN5Z1ZWVkxGdVUiLCJzdWIiOiJkaWQ6a2V5Ono2TWtnVml3ZnN0Q0wxTDlpOHRnc2RBWUV1NUE2Mlc1bUE5RGNtU3lnVlZWTEZ1VSJ9.zAndpciC3rYi6tmItYi8P9uGqkId_3TNEgJHeFeBA1fWgJ4aY8Y2a5RmeGHl4-fXMV8Ff1-tpR86z-6v7pkvDQ",
+                      "authorizationRequestUri": "https://d0ce-217-123-18-26.ngrok-free.app/siop/1ab30c0e-1adb-4f01-90e8-cfd425c0a311/authorization-requests/365d0d2f-e62b-4596-92cd-8c4baa7047d6",
+                      "state": "RequestUriRetrieved"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Get an OpenID4VC verification session by verification session id",
+        "tags": [
+          "OpenID4VC Verification Sessions"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "verificationSessionId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteVerificationSession",
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        },
+        "description": "Delete an OpenID4VC verification session by id",
+        "tags": [
+          "OpenID4VC Verification Sessions"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "verificationSessionId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      }
+    },
+    "/openid4vc/issuers": {
+      "post": {
+        "operationId": "CreateIssuer",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpenId4VcIssuerRecord"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "id": "65dff314-b7c8-4617-952e-a82864fecec5",
+                      "createdAt": "2024-03-29T15:26:58.347Z",
+                      "updatedAt": "2024-03-29T15:26:58.347Z",
+                      "type": "OpenId4VcIssuerRecord",
+                      "publicIssuerId": "129ea46f-92bc-4d44-8433-ac153b7da2e6",
+                      "accessTokenPublicKeyFingerprint": "z6MkrSAZxmNERyktTeT2ich4Ntu3TPc5RdcB4sCsEbZa4vzh",
+                      "credentialsSupported": [
+                        {
+                          "format": "vc+sd-jwt",
+                          "id": "ExampleCredentialSdJwtVc",
+                          "vct": "https://example.com/vct#ExampleCredential",
+                          "cryptographic_binding_methods_supported": [
+                            "did:key",
+                            "did:jwk"
+                          ],
+                          "cryptographic_suites_supported": [
+                            "ES256",
+                            "Ed25519"
+                          ],
+                          "display": [
+                            {
+                              "name": "Example SD JWT Credential",
+                              "description": "This is an example SD-JWT credential",
+                              "background_color": "#ffffff",
+                              "background_image": {
+                                "url": "https://example.com/background.png",
+                                "alt_text": "Example Credential Background"
+                              },
+                              "text_color": "#000000",
+                              "locale": "en-US",
+                              "logo": {
+                                "url": "https://example.com/logo.png",
+                                "alt_text": "Example Credential Logo"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "format": "jwt_vc_json",
+                          "id": "ExampleCredentialJwtVc",
+                          "types": [
+                            "VerifiableCredential",
+                            "ExampleCredential"
+                          ],
+                          "cryptographic_binding_methods_supported": [
+                            "did:key",
+                            "did:jwk"
+                          ],
+                          "cryptographic_suites_supported": [
+                            "ES256",
+                            "Ed25519"
+                          ],
+                          "display": [
+                            {
+                              "name": "Example SD JWT Credential",
+                              "description": "This is an example SD-JWT credential",
+                              "background_color": "#ffffff",
+                              "background_image": {
+                                "url": "https://example.com/background.png",
+                                "alt_text": "Example Credential Background"
+                              },
+                              "text_color": "#000000",
+                              "locale": "en-US",
+                              "logo": {
+                                "url": "https://example.com/logo.png",
+                                "alt_text": "Example Credential Logo"
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "display": [
+                        {
+                          "background_color": "#ffffff",
+                          "description": "This is an example issuer",
+                          "name": "Example Issuer",
+                          "locale": "en-US",
+                          "logo": {
+                            "alt_text": "Example Issuer Logo",
+                            "url": "https://example.com/logo.png"
+                          },
+                          "text_color": "#000000"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Create a new OpenID4VCI Issuer",
+        "tags": [
+          "OpenID4VC Issuers"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OpenId4VcIssuersCreateOptions"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "GetIssuersByQuery",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/OpenId4VcIssuerRecord"
+                  },
+                  "type": "array"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": [
+                      {
+                        "id": "65dff314-b7c8-4617-952e-a82864fecec5",
+                        "createdAt": "2024-03-29T15:26:58.347Z",
+                        "updatedAt": "2024-03-29T15:26:58.347Z",
+                        "type": "OpenId4VcIssuerRecord",
+                        "publicIssuerId": "129ea46f-92bc-4d44-8433-ac153b7da2e6",
+                        "accessTokenPublicKeyFingerprint": "z6MkrSAZxmNERyktTeT2ich4Ntu3TPc5RdcB4sCsEbZa4vzh",
+                        "credentialsSupported": [
+                          {
+                            "format": "vc+sd-jwt",
+                            "id": "ExampleCredentialSdJwtVc",
+                            "vct": "https://example.com/vct#ExampleCredential",
+                            "cryptographic_binding_methods_supported": [
+                              "did:key",
+                              "did:jwk"
+                            ],
+                            "cryptographic_suites_supported": [
+                              "ES256",
+                              "Ed25519"
+                            ],
+                            "display": [
+                              {
+                                "name": "Example SD JWT Credential",
+                                "description": "This is an example SD-JWT credential",
+                                "background_color": "#ffffff",
+                                "background_image": {
+                                  "url": "https://example.com/background.png",
+                                  "alt_text": "Example Credential Background"
+                                },
+                                "text_color": "#000000",
+                                "locale": "en-US",
+                                "logo": {
+                                  "url": "https://example.com/logo.png",
+                                  "alt_text": "Example Credential Logo"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "format": "jwt_vc_json",
+                            "id": "ExampleCredentialJwtVc",
+                            "types": [
+                              "VerifiableCredential",
+                              "ExampleCredential"
+                            ],
+                            "cryptographic_binding_methods_supported": [
+                              "did:key",
+                              "did:jwk"
+                            ],
+                            "cryptographic_suites_supported": [
+                              "ES256",
+                              "Ed25519"
+                            ],
+                            "display": [
+                              {
+                                "name": "Example SD JWT Credential",
+                                "description": "This is an example SD-JWT credential",
+                                "background_color": "#ffffff",
+                                "background_image": {
+                                  "url": "https://example.com/background.png",
+                                  "alt_text": "Example Credential Background"
+                                },
+                                "text_color": "#000000",
+                                "locale": "en-US",
+                                "logo": {
+                                  "url": "https://example.com/logo.png",
+                                  "alt_text": "Example Credential Logo"
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "display": [
+                          {
+                            "background_color": "#ffffff",
+                            "description": "This is an example issuer",
+                            "name": "Example Issuer",
+                            "locale": "en-US",
+                            "logo": {
+                              "alt_text": "Example Issuer Logo",
+                              "url": "https://example.com/logo.png"
+                            },
+                            "text_color": "#000000"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "OpenID4VC Issuers"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "publicIssuerId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      }
+    },
+    "/openid4vc/issuers/{issuerId}": {
+      "delete": {
+        "operationId": "DeleteIssuer",
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        },
+        "description": "Delete an OpenID4VCI issuer by id",
+        "tags": [
+          "OpenID4VC Issuers"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "issuerId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      },
+      "get": {
+        "operationId": "GetIssuer",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpenId4VcIssuerRecord"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "id": "65dff314-b7c8-4617-952e-a82864fecec5",
+                      "createdAt": "2024-03-29T15:26:58.347Z",
+                      "updatedAt": "2024-03-29T15:26:58.347Z",
+                      "type": "OpenId4VcIssuerRecord",
+                      "publicIssuerId": "129ea46f-92bc-4d44-8433-ac153b7da2e6",
+                      "accessTokenPublicKeyFingerprint": "z6MkrSAZxmNERyktTeT2ich4Ntu3TPc5RdcB4sCsEbZa4vzh",
+                      "credentialsSupported": [
+                        {
+                          "format": "vc+sd-jwt",
+                          "id": "ExampleCredentialSdJwtVc",
+                          "vct": "https://example.com/vct#ExampleCredential",
+                          "cryptographic_binding_methods_supported": [
+                            "did:key",
+                            "did:jwk"
+                          ],
+                          "cryptographic_suites_supported": [
+                            "ES256",
+                            "Ed25519"
+                          ],
+                          "display": [
+                            {
+                              "name": "Example SD JWT Credential",
+                              "description": "This is an example SD-JWT credential",
+                              "background_color": "#ffffff",
+                              "background_image": {
+                                "url": "https://example.com/background.png",
+                                "alt_text": "Example Credential Background"
+                              },
+                              "text_color": "#000000",
+                              "locale": "en-US",
+                              "logo": {
+                                "url": "https://example.com/logo.png",
+                                "alt_text": "Example Credential Logo"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "format": "jwt_vc_json",
+                          "id": "ExampleCredentialJwtVc",
+                          "types": [
+                            "VerifiableCredential",
+                            "ExampleCredential"
+                          ],
+                          "cryptographic_binding_methods_supported": [
+                            "did:key",
+                            "did:jwk"
+                          ],
+                          "cryptographic_suites_supported": [
+                            "ES256",
+                            "Ed25519"
+                          ],
+                          "display": [
+                            {
+                              "name": "Example SD JWT Credential",
+                              "description": "This is an example SD-JWT credential",
+                              "background_color": "#ffffff",
+                              "background_image": {
+                                "url": "https://example.com/background.png",
+                                "alt_text": "Example Credential Background"
+                              },
+                              "text_color": "#000000",
+                              "locale": "en-US",
+                              "logo": {
+                                "url": "https://example.com/logo.png",
+                                "alt_text": "Example Credential Logo"
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "display": [
+                        {
+                          "background_color": "#ffffff",
+                          "description": "This is an example issuer",
+                          "name": "Example Issuer",
+                          "locale": "en-US",
+                          "logo": {
+                            "alt_text": "Example Issuer Logo",
+                            "url": "https://example.com/logo.png"
+                          },
+                          "text_color": "#000000"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Get an OpenID4VCI issuer by id",
+        "tags": [
+          "OpenID4VC Issuers"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "issuerId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      },
+      "put": {
+        "operationId": "UpdateIssuerMetadata",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpenId4VcIssuerRecord"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "id": "65dff314-b7c8-4617-952e-a82864fecec5",
+                      "createdAt": "2024-03-29T15:26:58.347Z",
+                      "updatedAt": "2024-03-29T15:26:58.347Z",
+                      "type": "OpenId4VcIssuerRecord",
+                      "publicIssuerId": "129ea46f-92bc-4d44-8433-ac153b7da2e6",
+                      "accessTokenPublicKeyFingerprint": "z6MkrSAZxmNERyktTeT2ich4Ntu3TPc5RdcB4sCsEbZa4vzh",
+                      "credentialsSupported": [
+                        {
+                          "format": "vc+sd-jwt",
+                          "id": "ExampleCredentialSdJwtVc",
+                          "vct": "https://example.com/vct#ExampleCredential",
+                          "cryptographic_binding_methods_supported": [
+                            "did:key",
+                            "did:jwk"
+                          ],
+                          "cryptographic_suites_supported": [
+                            "ES256",
+                            "Ed25519"
+                          ],
+                          "display": [
+                            {
+                              "name": "Example SD JWT Credential",
+                              "description": "This is an example SD-JWT credential",
+                              "background_color": "#ffffff",
+                              "background_image": {
+                                "url": "https://example.com/background.png",
+                                "alt_text": "Example Credential Background"
+                              },
+                              "text_color": "#000000",
+                              "locale": "en-US",
+                              "logo": {
+                                "url": "https://example.com/logo.png",
+                                "alt_text": "Example Credential Logo"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "format": "jwt_vc_json",
+                          "id": "ExampleCredentialJwtVc",
+                          "types": [
+                            "VerifiableCredential",
+                            "ExampleCredential"
+                          ],
+                          "cryptographic_binding_methods_supported": [
+                            "did:key",
+                            "did:jwk"
+                          ],
+                          "cryptographic_suites_supported": [
+                            "ES256",
+                            "Ed25519"
+                          ],
+                          "display": [
+                            {
+                              "name": "Example SD JWT Credential",
+                              "description": "This is an example SD-JWT credential",
+                              "background_color": "#ffffff",
+                              "background_image": {
+                                "url": "https://example.com/background.png",
+                                "alt_text": "Example Credential Background"
+                              },
+                              "text_color": "#000000",
+                              "locale": "en-US",
+                              "logo": {
+                                "url": "https://example.com/logo.png",
+                                "alt_text": "Example Credential Logo"
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "display": [
+                        {
+                          "background_color": "#ffffff",
+                          "description": "This is an example issuer",
+                          "name": "Example Issuer",
+                          "locale": "en-US",
+                          "logo": {
+                            "alt_text": "Example Issuer Logo",
+                            "url": "https://example.com/logo.png"
+                          },
+                          "text_color": "#000000"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Update issuer metadata (`display` and `credentialsSupported`).\n\nNOTE: this method overwrites the existing metadata with the new metadata, so\nmake sure to include all the metadata you want to keep in the new metadata.",
+        "tags": [
+          "OpenID4VC Issuers"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "issuerId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OpenId4VcIssuersUpdateMetadataOptions"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openid4vc/issuers/sessions/create-offer": {
+      "post": {
+        "operationId": "CreateOffer",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpenId4VcIssuanceSessionsCreateOfferResponse"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "issuanceSession": {
+                        "id": "9cde9070-23c9-4e51-b810-e929a0298cbb",
+                        "createdAt": "2024-03-29T17:54:34.890Z",
+                        "updatedAt": "2024-03-29T17:54:34.890Z",
+                        "type": "OpenId4VcIssuanceSessionRecord",
+                        "publicIssuerId": "a868257d-7149-4d4d-a52c-78f3197ee538",
+                        "state": "OfferCreated",
+                        "preAuthorizedCode": "963352229993506863726932",
+                        "issuanceMetadata": {
+                          "credentials": [
+                            {
+                              "credentialSupportedId": "ExampleCredentialSdJwtVc",
+                              "format": "vc+sd-jwt",
+                              "issuer": {
+                                "method": "did",
+                                "didUrl": "did:key:z6MkgViwfstCL1L9i8tgsdAYEu5A62W5mA9DcmSygVVVLFuU#z6MkgViwfstCL1L9i8tgsdAYEu5A62W5mA9DcmSygVVVLFuU"
+                              },
+                              "payload": {
+                                "first_name": "John",
+                                "last_name": "Doe",
+                                "age": {
+                                  "over_18": true,
+                                  "over_21": true,
+                                  "over_65": false
+                                },
+                                "vct": "https://example.com/vct#ExampleCredential"
+                              },
+                              "disclosureFrame": {
+                                "first_name": false,
+                                "last_name": false,
+                                "age": {
+                                  "over_18": true,
+                                  "over_21": true,
+                                  "over_65": true
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        "credentialOfferPayload": {
+                          "grants": {
+                            "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
+                              "pre-authorized_code": "963352229993506863726932",
+                              "user_pin_required": false
+                            }
+                          },
+                          "credentials": [
+                            "ExampleCredentialSdJwtVc"
+                          ],
+                          "credential_issuer": "http://localhost:3008/oid4vci/a868257d-7149-4d4d-a52c-78f3197ee538"
+                        },
+                        "credentialOfferUri": "http://localhost:3008/oid4vci/a868257d-7149-4d4d-a52c-78f3197ee538/offers/4a85ea23-998c-4bbe-af0a-9b03a2b030db"
+                      },
+                      "credentialOffer": "openid-credential-offer://?credential_offer_uri=http%3A%2F%2Flocalhost%3A3008%2Foid4vci%2Fa868257d-7149-4d4d-a52c-78f3197ee538%2Foffers%2F4a85ea23-998c-4bbe-af0a-9b03a2b030db"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Create an OpenID4VC issuance session by creating a credential offer",
+        "tags": [
+          "OpenID4VC Issuance Sessions"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OpenId4VcIssuanceSessionsCreateOfferOptions"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openid4vc/issuers/sessions": {
+      "get": {
+        "operationId": "GetIssuanceSessionsByQuery",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/OpenId4VcIssuanceSessionRecord"
+                  },
+                  "type": "array"
+                }
+              }
+            }
+          }
+        },
+        "description": "Find all OpenID4VC issuance sessions by query",
+        "tags": [
+          "OpenID4VC Issuance Sessions"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "cNonce",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "publicIssuerId",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/PublicIssuerId"
+            }
+          },
+          {
+            "in": "query",
+            "name": "preAuthorizedCode",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "state",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/OpenId4VcIssuanceSessionState"
+            }
+          },
+          {
+            "in": "query",
+            "name": "credentialOfferUri",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      }
+    },
+    "/openid4vc/issuers/sessions/{issuanceSessionId}": {
+      "get": {
+        "operationId": "GetIssuanceSession",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpenId4VcIssuanceSessionRecord"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get an OpenID4VC issuance session by issuance session id",
+        "tags": [
+          "OpenID4VC Issuance Sessions"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "issuanceSessionId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteIssuanceSession",
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        },
+        "description": "Delete an OpenID4VC issuance session by id",
+        "tags": [
+          "OpenID4VC Issuance Sessions"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "issuanceSessionId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      }
+    },
+    "/didcomm/proofs": {
+      "get": {
+        "operationId": "FindProofsByQuery",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/DidCommProofExchangeRecord"
+                  },
+                  "type": "array"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": [
+                      {
+                        "id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+                        "protocolVersion": "v2",
+                        "role": "prover",
+                        "state": "proposal-sent",
+                        "threadId": "0019d466-5eea-4269-8c40-031b4896c5b7",
+                        "connectionId": "2aecf74c-3073-4f98-9acb-92415d096834",
+                        "createdAt": "2022-01-01T00:00:00.000Z",
+                        "autoAcceptProof": "always",
+                        "type": "ProofRecord"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Find proof exchanges by query",
+        "tags": [
+          "DIDComm Proofs"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "threadId",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/ThreadId"
+            }
+          },
+          {
+            "in": "query",
+            "name": "connectionId",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/RecordId"
+            }
+          },
+          {
+            "in": "query",
+            "name": "state",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/ProofState"
+            }
+          },
+          {
+            "in": "query",
+            "name": "parentThreadId",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/ThreadId"
+            }
+          },
+          {
+            "in": "query",
+            "name": "role",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/ProofRole"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      }
+    },
+    "/didcomm/proofs/{proofExchangeId}/format-data": {
+      "get": {
+        "operationId": "GetFormatDateForProofExchange",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DidCommProofsGetFormatDataResponse"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "request": {
+                        "anoncreds": {
+                          "name": "proof",
+                          "version": "1.0",
+                          "nonce": "758240050114745983655710",
+                          "requested_attributes": {
+                            "prop1": {
+                              "restrictions": [
+                                {
+                                  "cred_def_id": "credential-definition:_p5hLM-uQa1zWnn3tBlSZjLHN3_jrHOq48HZg9x0WNU"
+                                }
+                              ],
+                              "name": "prop1"
+                            }
+                          },
+                          "requested_predicates": {}
+                        }
+                      },
+                      "presentation": {
+                        "anoncreds": {
+                          "proof": {
+                            "proofs": [
+                              {
+                                "primary_proof": {
+                                  "eq_proof": {
+                                    "revealed_attrs": {
+                                      "prop1": "27034640024117331033063128044004318218486816931520886405535659934417438781507"
+                                    },
+                                    "a_prime": "19047116433504188994272881641822894872902270927119448171860075215300057790220032716001623222457003097557526300243774256052213342685786339664359702293068763238941477983249827037208391202082237355452899615066813136375104369999353835295981406017700484554961999776491254535901817543204922312909798679047221330019235737943019299392326535879346715038129185356279868745469303380007785962003959306434843861572801946425200870616819278614278447453156100921293441241791644660148472591502140793919913129642727070863794832260096533561211015144668753888527444212286891447285472223278089710845256263784748983746718325771142088732939",
+                                    "e": "10259898129295787961743851056978055195603429485644503254324436416167764909267793244904075766652236796402891954383818563601919019183718168",
+                                    "v": "1231362115035007024570764941449044031590844390550471600312531446117722154659868456888335013946335458040274898035202658225595068963856089705169119329625310606633779849291885735720644454949213413794453812488717746459159104479357614205354859977539345197819006257295943057033308104945137276434448035162025255321821437631597083690718246293836723511817575318157392852647929432326303080306792286331173382522988459574485523423956289579780768305214142906216511255127647152962121322858014142270114082615381637234314728038304949470391361208405519610497147621327793260813179177368913095571745867719207542759576560425897236709768313140801020933801485735855445633964031941661640923635020541019781997653754765174059228323815763523970880399098098455858988336056250017116998250153813329152217051921736584301286899814639213197350128774690139583010473926868949760824128601421310373158774629991706471289635887140592649446912506997480513587053",
+                                    "m": {
+                                      "prop2": "16162691443890709574767645052161691434918099895053484805751392155204331411424414052735813491020922097673389640501460090756960039580468937518501805646597654106586801848678500913986",
+                                      "master_secret": "10922412082717230367748516141129893501521277218767044762649924912605238791909366369223988111691711544332629968246354239716138904917009438604729675733830274629976624843073297367700"
+                                    },
+                                    "m2": "143283050199231500752147520595402404430732435435603814807867477210654907867800083910082782289810115670692637233938031314254705029316478576894690559684263226485325994959779501355610180066672024099090659111271057300388050170242803008137083396212408809319025355910950905661669766118741906012674213690293786101106250316977895458665512868288955286373377155511034215107395178211834003022495581825841682012396310023015657545525739013246143790276942948375829743916303018361158237084452134993073397899480348489140658247064717903765898129567455078992931912070154142338171836287509698783369557812496197648966004949431901163349211745070465330233452514957502613847594191716703134436607494648786994546260304783197646882841310437319877565249799794"
+                                  },
+                                  "ge_proofs": []
+                                },
+                                "non_revoc_proof": null
+                              }
+                            ],
+                            "aggregated_proof": {
+                              "c_hash": "76178432210457409800554029394836415101930849642483382585409939514864801686752",
+                              "c_list": [
+                                [
+                                  150,
+                                  225,
+                                  217,
+                                  140,
+                                  172,
+                                  223,
+                                  12,
+                                  66,
+                                  140,
+                                  46,
+                                  192,
+                                  81,
+                                  148,
+                                  134,
+                                  190,
+                                  64,
+                                  6,
+                                  79,
+                                  137,
+                                  224,
+                                  183,
+                                  196,
+                                  1,
+                                  53,
+                                  74,
+                                  202,
+                                  142,
+                                  207,
+                                  205,
+                                  85,
+                                  68,
+                                  149,
+                                  183,
+                                  231,
+                                  102,
+                                  151,
+                                  99,
+                                  207,
+                                  81,
+                                  103,
+                                  28,
+                                  162,
+                                  11,
+                                  32,
+                                  124,
+                                  123,
+                                  124,
+                                  16,
+                                  110,
+                                  54,
+                                  177,
+                                  85,
+                                  202,
+                                  169,
+                                  186,
+                                  146,
+                                  134,
+                                  43,
+                                  149,
+                                  79,
+                                  220,
+                                  161,
+                                  129,
+                                  15,
+                                  229,
+                                  253,
+                                  44,
+                                  250,
+                                  129,
+                                  223,
+                                  194,
+                                  175,
+                                  101,
+                                  181,
+                                  78,
+                                  155,
+                                  71,
+                                  122,
+                                  9,
+                                  131,
+                                  166,
+                                  178,
+                                  239,
+                                  35,
+                                  72,
+                                  64,
+                                  93,
+                                  160,
+                                  230,
+                                  202,
+                                  255,
+                                  4,
+                                  121,
+                                  243,
+                                  107,
+                                  81,
+                                  38,
+                                  10,
+                                  98,
+                                  80,
+                                  62,
+                                  15,
+                                  180,
+                                  7,
+                                  148,
+                                  52,
+                                  164,
+                                  154,
+                                  45,
+                                  154,
+                                  104,
+                                  10,
+                                  156,
+                                  144,
+                                  223,
+                                  255,
+                                  132,
+                                  248,
+                                  109,
+                                  87,
+                                  40,
+                                  167,
+                                  194,
+                                  139,
+                                  49,
+                                  3,
+                                  153,
+                                  175,
+                                  119,
+                                  231,
+                                  156,
+                                  204,
+                                  54,
+                                  41,
+                                  26,
+                                  79,
+                                  19,
+                                  169,
+                                  153,
+                                  192,
+                                  102,
+                                  105,
+                                  168,
+                                  90,
+                                  5,
+                                  21,
+                                  249,
+                                  187,
+                                  26,
+                                  176,
+                                  136,
+                                  204,
+                                  113,
+                                  73,
+                                  240,
+                                  143,
+                                  56,
+                                  121,
+                                  23,
+                                  77,
+                                  112,
+                                  126,
+                                  222,
+                                  54,
+                                  233,
+                                  110,
+                                  73,
+                                  70,
+                                  77,
+                                  9,
+                                  135,
+                                  65,
+                                  186,
+                                  27,
+                                  22,
+                                  140,
+                                  137,
+                                  169,
+                                  230,
+                                  49,
+                                  191,
+                                  60,
+                                  66,
+                                  8,
+                                  136,
+                                  88,
+                                  183,
+                                  240,
+                                  225,
+                                  80,
+                                  151,
+                                  123,
+                                  45,
+                                  110,
+                                  91,
+                                  222,
+                                  242,
+                                  236,
+                                  20,
+                                  123,
+                                  104,
+                                  154,
+                                  187,
+                                  164,
+                                  96,
+                                  46,
+                                  218,
+                                  129,
+                                  133,
+                                  233,
+                                  225,
+                                  252,
+                                  77,
+                                  139,
+                                  163,
+                                  93,
+                                  117,
+                                  171,
+                                  78,
+                                  170,
+                                  16,
+                                  99,
+                                  127,
+                                  232,
+                                  161,
+                                  106,
+                                  41,
+                                  94,
+                                  177,
+                                  179,
+                                  9,
+                                  216,
+                                  233,
+                                  175,
+                                  192,
+                                  36,
+                                  45,
+                                  192,
+                                  148,
+                                  173,
+                                  217,
+                                  7,
+                                  43,
+                                  188,
+                                  80,
+                                  79,
+                                  183,
+                                  230,
+                                  183,
+                                  166,
+                                  117,
+                                  48,
+                                  1,
+                                  253,
+                                  177,
+                                  11
+                                ]
+                              ]
+                            }
+                          },
+                          "requested_proof": {
+                            "revealed_attrs": {
+                              "prop1": {
+                                "sub_proof_index": 0,
+                                "raw": "Alice",
+                                "encoded": "27034640024117331033063128044004318218486816931520886405535659934417438781507"
+                              }
+                            },
+                            "self_attested_attrs": {},
+                            "unrevealed_attrs": {},
+                            "predicates": {}
+                          },
+                          "identifiers": [
+                            {
+                              "schema_id": "schema:gSl0JkGIcmRif593Q6XYGsJndHGOzm1jWRFa-Lwrz9o",
+                              "cred_def_id": "credential-definition:_p5hLM-uQa1zWnn3tBlSZjLHN3_jrHOq48HZg9x0WNU"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve the format data associated with a proof exchange",
+        "tags": [
+          "DIDComm Proofs"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "proofExchangeId",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/RecordId"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      }
+    },
+    "/didcomm/proofs/{proofExchangeId}": {
+      "get": {
+        "operationId": "GetProofExchangeById",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DidCommProofExchangeRecord"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+                      "protocolVersion": "v2",
+                      "role": "prover",
+                      "state": "proposal-sent",
+                      "threadId": "0019d466-5eea-4269-8c40-031b4896c5b7",
+                      "connectionId": "2aecf74c-3073-4f98-9acb-92415d096834",
+                      "createdAt": "2022-01-01T00:00:00.000Z",
+                      "autoAcceptProof": "always",
+                      "type": "ProofRecord"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve proof exchange by proof exchange id",
+        "tags": [
+          "DIDComm Proofs"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "proofExchangeId",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/RecordId"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteProof",
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        },
+        "description": "Deletes a proof exchange record.",
+        "tags": [
+          "DIDComm Proofs"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "proofExchangeId",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/RecordId"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      }
+    },
+    "/didcomm/proofs/propose-proof": {
+      "post": {
+        "operationId": "ProposeProof",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DidCommProofExchangeRecord"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+                      "protocolVersion": "v2",
+                      "role": "prover",
+                      "state": "proposal-sent",
+                      "threadId": "0019d466-5eea-4269-8c40-031b4896c5b7",
+                      "connectionId": "2aecf74c-3073-4f98-9acb-92415d096834",
+                      "createdAt": "2022-01-01T00:00:00.000Z",
+                      "autoAcceptProof": "always",
+                      "type": "ProofRecord"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Initiate a new presentation exchange as prover by sending a presentation proposal request\nto the connection with the specified connection id.",
+        "tags": [
+          "DIDComm Proofs"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DidCommProofsProposeProofOptions"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/didcomm/proofs/{proofExchangeId}/accept-proposal": {
+      "post": {
+        "operationId": "AcceptProposal",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DidCommProofExchangeRecord"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+                      "protocolVersion": "v2",
+                      "role": "prover",
+                      "state": "proposal-sent",
+                      "threadId": "0019d466-5eea-4269-8c40-031b4896c5b7",
+                      "connectionId": "2aecf74c-3073-4f98-9acb-92415d096834",
+                      "createdAt": "2022-01-01T00:00:00.000Z",
+                      "autoAcceptProof": "always",
+                      "type": "ProofRecord"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Accept a presentation proposal as verifier by sending an accept proposal message\nto the connection associated with the proof record.",
+        "tags": [
+          "DIDComm Proofs"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "proofExchangeId",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/RecordId"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DidCommProofsAcceptProposalOptions"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/didcomm/proofs/create-request": {
+      "post": {
+        "operationId": "CreateRequest",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DidCommProofsCreateRequestResponse"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "proofExchange": {
+                        "id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+                        "protocolVersion": "v2",
+                        "role": "prover",
+                        "state": "proposal-sent",
+                        "threadId": "0019d466-5eea-4269-8c40-031b4896c5b7",
+                        "connectionId": "2aecf74c-3073-4f98-9acb-92415d096834",
+                        "createdAt": "2022-01-01T00:00:00.000Z",
+                        "autoAcceptProof": "always",
+                        "type": "ProofRecord"
+                      },
+                      "message": {
+                        "@id": "134b27f0-9366-4811-a36b-50bacfe57e61",
+                        "@type": "https://didcomm.org/present-proof/1.0/request-presentation"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Creates a presentation request not bound to any proposal or existing connection",
+        "tags": [
+          "DIDComm Proofs"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DidCommProofsCreateRequestOptions"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/didcomm/proofs/request-proof": {
+      "post": {
+        "operationId": "RequestProof",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {},
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+                      "protocolVersion": "v2",
+                      "role": "prover",
+                      "state": "proposal-sent",
+                      "threadId": "0019d466-5eea-4269-8c40-031b4896c5b7",
+                      "connectionId": "2aecf74c-3073-4f98-9acb-92415d096834",
+                      "createdAt": "2022-01-01T00:00:00.000Z",
+                      "autoAcceptProof": "always",
+                      "type": "ProofRecord"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Creates a presentation request bound to existing connection",
+        "tags": [
+          "DIDComm Proofs"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DidCommProofsSendRequestOptions"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/didcomm/proofs/{proofExchangeId}/accept-request": {
+      "post": {
+        "operationId": "AcceptRequest",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {},
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+                      "protocolVersion": "v2",
+                      "role": "prover",
+                      "state": "proposal-sent",
+                      "threadId": "0019d466-5eea-4269-8c40-031b4896c5b7",
+                      "connectionId": "2aecf74c-3073-4f98-9acb-92415d096834",
+                      "createdAt": "2022-01-01T00:00:00.000Z",
+                      "autoAcceptProof": "always",
+                      "type": "ProofRecord"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Accept a presentation request as prover by sending an accept request message\nto the connection associated with the proof record.",
+        "tags": [
+          "DIDComm Proofs"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "proofExchangeId",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/RecordId"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DidCommProofsAcceptRequestOptions"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/didcomm/proofs/{proofExchangeId}/accept-presentation": {
+      "post": {
+        "operationId": "AcceptPresentation",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {},
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+                      "protocolVersion": "v2",
+                      "role": "prover",
+                      "state": "proposal-sent",
+                      "threadId": "0019d466-5eea-4269-8c40-031b4896c5b7",
+                      "connectionId": "2aecf74c-3073-4f98-9acb-92415d096834",
+                      "createdAt": "2022-01-01T00:00:00.000Z",
+                      "autoAcceptProof": "always",
+                      "type": "ProofRecord"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Accept a presentation as prover by sending an accept presentation message\nto the connection associated with the proof record.",
+        "tags": [
+          "DIDComm Proofs"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "proofExchangeId",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/RecordId"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      }
+    },
+    "/didcomm/out-of-band": {
+      "get": {
+        "operationId": "FindOutOfBandRecordsByQuery",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/DidCommOutOfBandRecord"
+                  },
+                  "type": "array"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": [
+                      {
+                        "outOfBandInvitation": {
+                          "@type": "https://didcomm.org/out-of-band/1.1/invitation",
+                          "@id": "d6472943-e5d0-4d95-8b48-790ed5a41931",
+                          "label": "Aries Test Agent",
+                          "accept": [
+                            "didcomm/aip1",
+                            "didcomm/aip2;env=rfc19"
+                          ],
+                          "handshake_protocols": [
+                            "https://didcomm.org/didexchange/1.0",
+                            "https://didcomm.org/connections/1.0"
+                          ],
+                          "services": [
+                            {
+                              "id": "#inline-0",
+                              "serviceEndpoint": "https://6b77-89-20-162-146.ngrok.io",
+                              "type": "did-communication",
+                              "recipientKeys": [
+                                "did:key:z6MkmTBHTWrvLPN8pBmUj7Ye5ww9GiacXCYMNVvpScSpf1DM"
+                              ],
+                              "routingKeys": []
+                            }
+                          ]
+                        },
+                        "id": "42a95528-0e30-4f86-a462-0efb02178b53",
+                        "createdAt": "2022-01-01T00:00:00.000Z",
+                        "role": "sender",
+                        "state": "prepare-response",
+                        "reusable": false,
+                        "type": "OutOfBandRecord"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve all out of band records by query",
+        "tags": [
+          "DIDComm Out Of Band"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "invitationId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "role",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/OutOfBandRole"
+            }
+          },
+          {
+            "in": "query",
+            "name": "state",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/OutOfBandState"
+            }
+          },
+          {
+            "in": "query",
+            "name": "threadId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      }
+    },
+    "/didcomm/out-of-band/{outOfBandId}": {
+      "get": {
+        "operationId": "GetOutOfBandRecordById",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DidCommOutOfBandRecord"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "outOfBandInvitation": {
+                        "@type": "https://didcomm.org/out-of-band/1.1/invitation",
+                        "@id": "d6472943-e5d0-4d95-8b48-790ed5a41931",
+                        "label": "Aries Test Agent",
+                        "accept": [
+                          "didcomm/aip1",
+                          "didcomm/aip2;env=rfc19"
+                        ],
+                        "handshake_protocols": [
+                          "https://didcomm.org/didexchange/1.0",
+                          "https://didcomm.org/connections/1.0"
+                        ],
+                        "services": [
+                          {
+                            "id": "#inline-0",
+                            "serviceEndpoint": "https://6b77-89-20-162-146.ngrok.io",
+                            "type": "did-communication",
+                            "recipientKeys": [
+                              "did:key:z6MkmTBHTWrvLPN8pBmUj7Ye5ww9GiacXCYMNVvpScSpf1DM"
+                            ],
+                            "routingKeys": []
+                          }
+                        ]
+                      },
+                      "id": "42a95528-0e30-4f86-a462-0efb02178b53",
+                      "createdAt": "2022-01-01T00:00:00.000Z",
+                      "role": "sender",
+                      "state": "prepare-response",
+                      "reusable": false,
+                      "type": "OutOfBandRecord"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve an out of band record by id",
+        "tags": [
+          "DIDComm Out Of Band"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "outOfBandId",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/RecordId"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteOutOfBandRecord",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "description": "Deletes an out of band record from the repository.",
+        "tags": [
+          "DIDComm Out Of Band"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "outOfBandId",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/RecordId"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      }
+    },
+    "/didcomm/out-of-band/create-invitation": {
+      "post": {
+        "operationId": "CreateInvitation",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DidCommOutOfBandCreateInvitationResponse"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "invitationUrl": "https://example.com/?",
+                      "invitation": {
+                        "@type": "https://didcomm.org/out-of-band/1.1/invitation",
+                        "@id": "d6472943-e5d0-4d95-8b48-790ed5a41931",
+                        "label": "Aries Test Agent",
+                        "accept": [
+                          "didcomm/aip1",
+                          "didcomm/aip2;env=rfc19"
+                        ],
+                        "handshake_protocols": [
+                          "https://didcomm.org/didexchange/1.0",
+                          "https://didcomm.org/connections/1.0"
+                        ],
+                        "services": [
+                          {
+                            "id": "#inline-0",
+                            "serviceEndpoint": "https://6b77-89-20-162-146.ngrok.io",
+                            "type": "did-communication",
+                            "recipientKeys": [
+                              "did:key:z6MkmTBHTWrvLPN8pBmUj7Ye5ww9GiacXCYMNVvpScSpf1DM"
+                            ],
+                            "routingKeys": []
+                          }
+                        ]
+                      },
+                      "outOfBandRecord": {
+                        "outOfBandInvitation": {
+                          "@type": "https://didcomm.org/out-of-band/1.1/invitation",
+                          "@id": "d6472943-e5d0-4d95-8b48-790ed5a41931",
+                          "label": "Aries Test Agent",
+                          "accept": [
+                            "didcomm/aip1",
+                            "didcomm/aip2;env=rfc19"
+                          ],
+                          "handshake_protocols": [
+                            "https://didcomm.org/didexchange/1.0",
+                            "https://didcomm.org/connections/1.0"
+                          ],
+                          "services": [
+                            {
+                              "id": "#inline-0",
+                              "serviceEndpoint": "https://6b77-89-20-162-146.ngrok.io",
+                              "type": "did-communication",
+                              "recipientKeys": [
+                                "did:key:z6MkmTBHTWrvLPN8pBmUj7Ye5ww9GiacXCYMNVvpScSpf1DM"
+                              ],
+                              "routingKeys": []
+                            }
+                          ]
+                        },
+                        "id": "42a95528-0e30-4f86-a462-0efb02178b53",
+                        "createdAt": "2022-01-01T00:00:00.000Z",
+                        "role": "sender",
+                        "state": "prepare-response",
+                        "reusable": false,
+                        "type": "OutOfBandRecord"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Creates an outbound out-of-band record containing out-of-band invitation message defined in\nAries RFC 0434: Out-of-Band Protocol 1.1.",
+        "tags": [
+          "DIDComm Out Of Band"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DidCommOutOfBandCreateInvitationOptions"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/didcomm/out-of-band/create-legacy-invitation": {
+      "post": {
+        "operationId": "CreateLegacyInvitation",
+        "responses": {
+          "200": {
+            "description": "out-of-band record and invitation",
+            "content": {
+              "application/json": {
+                "schema": {},
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "invitation": {
+                        "@type": "https://didcomm.org/connections/1./invitation",
+                        "@id": "d6b23733-be49-408b-98ab-ba9460384087"
+                      },
+                      "outOfBandRecord": {
+                        "outOfBandInvitation": {
+                          "@type": "https://didcomm.org/out-of-band/1.1/invitation",
+                          "@id": "d6472943-e5d0-4d95-8b48-790ed5a41931",
+                          "label": "Aries Test Agent",
+                          "accept": [
+                            "didcomm/aip1",
+                            "didcomm/aip2;env=rfc19"
+                          ],
+                          "handshake_protocols": [
+                            "https://didcomm.org/didexchange/1.0",
+                            "https://didcomm.org/connections/1.0"
+                          ],
+                          "services": [
+                            {
+                              "id": "#inline-0",
+                              "serviceEndpoint": "https://6b77-89-20-162-146.ngrok.io",
+                              "type": "did-communication",
+                              "recipientKeys": [
+                                "did:key:z6MkmTBHTWrvLPN8pBmUj7Ye5ww9GiacXCYMNVvpScSpf1DM"
+                              ],
+                              "routingKeys": []
+                            }
+                          ]
+                        },
+                        "id": "42a95528-0e30-4f86-a462-0efb02178b53",
+                        "createdAt": "2022-01-01T00:00:00.000Z",
+                        "role": "sender",
+                        "state": "prepare-response",
+                        "reusable": false,
+                        "type": "OutOfBandRecord"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Creates an outbound out-of-band record in the same way how `createInvitation` method does it,\nbut it also converts out-of-band invitation message to an \"legacy\" invitation message defined\nin RFC 0160: Connection Protocol and returns it together with out-of-band record.",
+        "tags": [
+          "DIDComm Out Of Band"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DidCommOutOfBandCreateLegacyConnectionInvitationOptions"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/didcomm/out-of-band/create-legacy-connectionless-invitation": {
+      "post": {
+        "operationId": "CreateLegacyConnectionlessInvitation",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {},
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "message": {
+                        "@id": "eac4ff4e-b4fb-4c1d-aef3-b29c89d1cc00",
+                        "@type": "https://didcomm.org/issue-credential/1.0/offer-credential"
+                      },
+                      "invitationUrl": "http://example.com/invitation_url"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Creates a new connectionless legacy invitation.\n\nOnly works with messages created from:\n- /didcomm/credentials/create-offer\n- /didcomm/poofs/create-request",
+        "tags": [
+          "DIDComm Out Of Band"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DidCommOutOfBandCreateLegacyConnectionlessInvitationOptions"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/didcomm/out-of-band/receive-invitation": {
+      "post": {
+        "operationId": "ReceiveInvitation",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {},
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "outOfBandRecord": {
+                        "outOfBandInvitation": {
+                          "@type": "https://didcomm.org/out-of-band/1.1/invitation",
+                          "@id": "d6472943-e5d0-4d95-8b48-790ed5a41931",
+                          "label": "Aries Test Agent",
+                          "accept": [
+                            "didcomm/aip1",
+                            "didcomm/aip2;env=rfc19"
+                          ],
+                          "handshake_protocols": [
+                            "https://didcomm.org/didexchange/1.0",
+                            "https://didcomm.org/connections/1.0"
+                          ],
+                          "services": [
+                            {
+                              "id": "#inline-0",
+                              "serviceEndpoint": "https://6b77-89-20-162-146.ngrok.io",
+                              "type": "did-communication",
+                              "recipientKeys": [
+                                "did:key:z6MkmTBHTWrvLPN8pBmUj7Ye5ww9GiacXCYMNVvpScSpf1DM"
+                              ],
+                              "routingKeys": []
+                            }
+                          ]
+                        },
+                        "id": "42a95528-0e30-4f86-a462-0efb02178b53",
+                        "createdAt": "2022-01-01T00:00:00.000Z",
+                        "role": "sender",
+                        "state": "prepare-response",
+                        "reusable": false,
+                        "type": "OutOfBandRecord"
+                      },
+                      "connectionRecord": {
+                        "id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+                        "type": "ConnectionRecord",
+                        "createdAt": "2022-01-01T00:00:00.000Z",
+                        "did": "did:peer:1zQmfQh1T3rSqarP2FZ37uKjdQHPKFdVyo2mGiAPHZ8Ep7hv",
+                        "state": "invitation-sent",
+                        "role": "responder",
+                        "invitationDid": "did:peer:2.SeyJzIjoiaHR0cHM6Ly9kYTIzLTg5LTIwLTE2Mi0xNDYubmdyb2suaW8iLCJ0IjoiZGlkLWNvbW11bmljYXRpb24iLCJwcmlvcml0eSI6MCwicmVjaXBpZW50S2V5cyI6WyJkaWQ6a2V5Ono2TWtualg3U1lXRmdHMThCYkNEZHJnemhuQnA0UlhyOGVITHZxQ3FvRXllckxiTiN6Nk1rbmpYN1NZV0ZnRzE4QmJDRGRyZ3pobkJwNFJYcjhlSEx2cUNxb0V5ZXJMYk4iXSwiciI6W119",
+                        "outOfBandId": "edbc89fe-785f-4774-a288-46012486881d"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Receive an out of band invitation. Supports urls as well as JSON messages. Also supports legacy\nconnection invitations",
+        "tags": [
+          "DIDComm Out Of Band"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DidCommOutOfBandReceiveInvitationOptions"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/didcomm/out-of-band/{outOfBandId}/accept-invitation": {
+      "post": {
+        "operationId": "AcceptInvitation",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {},
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "outOfBandRecord": {
+                        "outOfBandInvitation": {
+                          "@type": "https://didcomm.org/out-of-band/1.1/invitation",
+                          "@id": "d6472943-e5d0-4d95-8b48-790ed5a41931",
+                          "label": "Aries Test Agent",
+                          "accept": [
+                            "didcomm/aip1",
+                            "didcomm/aip2;env=rfc19"
+                          ],
+                          "handshake_protocols": [
+                            "https://didcomm.org/didexchange/1.0",
+                            "https://didcomm.org/connections/1.0"
+                          ],
+                          "services": [
+                            {
+                              "id": "#inline-0",
+                              "serviceEndpoint": "https://6b77-89-20-162-146.ngrok.io",
+                              "type": "did-communication",
+                              "recipientKeys": [
+                                "did:key:z6MkmTBHTWrvLPN8pBmUj7Ye5ww9GiacXCYMNVvpScSpf1DM"
+                              ],
+                              "routingKeys": []
+                            }
+                          ]
+                        },
+                        "id": "42a95528-0e30-4f86-a462-0efb02178b53",
+                        "createdAt": "2022-01-01T00:00:00.000Z",
+                        "role": "sender",
+                        "state": "prepare-response",
+                        "reusable": false,
+                        "type": "OutOfBandRecord"
+                      },
+                      "connectionRecord": {
+                        "id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+                        "type": "ConnectionRecord",
+                        "createdAt": "2022-01-01T00:00:00.000Z",
+                        "did": "did:peer:1zQmfQh1T3rSqarP2FZ37uKjdQHPKFdVyo2mGiAPHZ8Ep7hv",
+                        "state": "invitation-sent",
+                        "role": "responder",
+                        "invitationDid": "did:peer:2.SeyJzIjoiaHR0cHM6Ly9kYTIzLTg5LTIwLTE2Mi0xNDYubmdyb2suaW8iLCJ0IjoiZGlkLWNvbW11bmljYXRpb24iLCJwcmlvcml0eSI6MCwicmVjaXBpZW50S2V5cyI6WyJkaWQ6a2V5Ono2TWtualg3U1lXRmdHMThCYkNEZHJnemhuQnA0UlhyOGVITHZxQ3FvRXllckxiTiN6Nk1rbmpYN1NZV0ZnRzE4QmJDRGRyZ3pobkJwNFJYcjhlSEx2cUNxb0V5ZXJMYk4iXSwiciI6W119",
+                        "outOfBandId": "edbc89fe-785f-4774-a288-46012486881d"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Accept a connection invitation as invitee (by sending a connection request message) for the connection with the specified connection id.\nThis is not needed when auto accepting of connections is enabled.",
+        "tags": [
+          "DIDComm Out Of Band"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "outOfBandId",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/RecordId"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DidCommOutOfBandAcceptInvitationOptions"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/didcomm/credentials": {
+      "get": {
+        "operationId": "FindCredentialsByQuery",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/DidCommCredentialExchangeRecord"
+                  },
+                  "type": "array"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": [
+                      {
+                        "credentials": [],
+                        "type": "CredentialRecord",
+                        "role": "holder",
+                        "id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+                        "createdAt": "2022-01-01T00:00:00.000Z",
+                        "state": "offer-sent",
+                        "connectionId": "ac6d0fdd-0db8-4f52-8a3d-de7ff8ddc14b",
+                        "threadId": "82701488-b43c-4d7b-9244-4bb204a7ae26",
+                        "credentialAttributes": [],
+                        "protocolVersion": "v1"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve all credential exchange records by query",
+        "tags": [
+          "DIDComm Credentials"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "threadId",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/ThreadId"
+            }
+          },
+          {
+            "in": "query",
+            "name": "parentThreadId",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/ThreadId"
+            }
+          },
+          {
+            "in": "query",
+            "name": "connectionId",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/RecordId"
+            }
+          },
+          {
+            "in": "query",
+            "name": "state",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/CredentialState"
+            }
+          },
+          {
+            "in": "query",
+            "name": "role",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/CredentialRole"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      }
+    },
+    "/didcomm/credentials/{credentialExchangeId}": {
+      "get": {
+        "operationId": "GetCredentialById",
+        "responses": {
+          "200": {
+            "description": "CredentialExchangeRecord",
+            "content": {
+              "application/json": {
+                "schema": {},
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "credentials": [],
+                      "type": "CredentialRecord",
+                      "role": "holder",
+                      "id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+                      "createdAt": "2022-01-01T00:00:00.000Z",
+                      "state": "offer-sent",
+                      "connectionId": "ac6d0fdd-0db8-4f52-8a3d-de7ff8ddc14b",
+                      "threadId": "82701488-b43c-4d7b-9244-4bb204a7ae26",
+                      "credentialAttributes": [],
+                      "protocolVersion": "v1"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve credential exchange record by credential record id",
+        "tags": [
+          "DIDComm Credentials"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "credentialExchangeId",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/RecordId"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteCredential",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "description": "Deletes a credential exchange record in the credential repository.",
+        "tags": [
+          "DIDComm Credentials"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "credentialExchangeId",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/RecordId"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      }
+    },
+    "/didcomm/credentials/{credentialExchangeId}/format-data": {
+      "get": {
+        "operationId": "GetFormatDateForCredentialExchange",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DidCommCredentialsGetFormatDataResponse"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "offerAttributes": [
+                        {
+                          "mime-type": "text/plain",
+                          "name": "prop1",
+                          "value": "Alice"
+                        },
+                        {
+                          "mime-type": "text/plain",
+                          "name": "prop2",
+                          "value": "Bob"
+                        }
+                      ],
+                      "offer": {
+                        "anoncreds": {
+                          "schema_id": "schema:gSl0JkGIcmRif593Q6XYGsJndHGOzm1jWRFa-Lwrz9o",
+                          "cred_def_id": "credential-definition:_p5hLM-uQa1zWnn3tBlSZjLHN3_jrHOq48HZg9x0WNU",
+                          "key_correctness_proof": {
+                            "c": "99492103123537767435780273140747875256790346132054146213963860002839562036500",
+                            "xz_cap": "580439401883808314813871954452291264672809884147416670644868202601349938534100012582121009892201828623456062583253712122390217453057344836461080181231409709931412795314081026936945930855825367373487243407763891173044774127684739520982825154953842442273813308991169090527022468436144816388847602118294979269313055482643679093387752228933342461551523525381348315077261080667315083376665151670823724165412812789868725296452469727913099297098501657154305553628601670242915979173502981519452691532364945800381784094698957899207092852251635741642974685343076909543754528139524390330974942129175514270934196165227837447039632098505018004458669992226178741765564079908532417644335223001107373553800636",
+                            "xr_cap": [
+                              [
+                                "prop2",
+                                "995399175086393290156643492153533410460088296042299023071321712767423823125266832866393832677059827513393172141469698615988398481324616362988306901757713912635730675164176333343113543425145312139791479962174299119310631546985779208764729297940146997294517195382469523212546412350946365060108495261812541753519099438498374096964273878810634998095141423219246735648908552325440689746900928839923227716273385790878307688202350090032242160533886272557839856485554366696826060620961486642370355665610549033927229155523847761590023494696062955267842162962594983582064910274022357686360792641497125074245699228183099824304332072233714267713611371961270313585807822270849608871260298873632530881181868"
+                              ],
+                              [
+                                "prop1",
+                                "1332724481340046129877312153176690921485462825381114334570976976911683740241735795674573565883450256485008453985793480391949571168596993894012183159420293482819645749037942541031221713594705004813170460963384907003707588246318592228064786935434434436493334335846541085008786621396358737393954898248156584956789603719162774096077144488775239706705659235938222621701852501004590177199881330248514156406621561858785958857377365259412279939255354717554715259409741463035067370342340375245558605525782229283165954317144433290958178245662795970871238028493809988026433044315609370187889271966194713168137139044017058936597616750741033931501545012220127203710939560438531093698046054460328575918119603"
+                              ],
+                              [
+                                "master_secret",
+                                "555027667428826242052970636449944760049716355932181005994059994704109863707489157610003651613465020982803541959788424930381416736220275982020574537155052939117498439344162350344720165428803548470057405536121354129959126518248455145191069141936666484179865018445996249913288495893190150238690838395991946573833346853053011240922319143499605693196163287075552588023831726135219961691799755462617042764987540423466441420500952919498995496310058387923814988140775894040589217067406516222451334977386486085574931826246195042640621402064770528877288327158750876201208151309067281791780644173220251685733148275860559683101771901936515172131760435059336917112277256735606589048477347147443664213752574"
+                              ]
+                            ]
+                          },
+                          "nonce": "692456490106322710069916"
+                        }
+                      },
+                      "request": {
+                        "anoncreds": {
+                          "entropy": "283559102751594275830315",
+                          "cred_def_id": "credential-definition:_p5hLM-uQa1zWnn3tBlSZjLHN3_jrHOq48HZg9x0WNU",
+                          "blinded_ms": {
+                            "u": "58231223348966103131811162273993912136371812752782223808009746737780125568145868523057859605972791511440980139494915406073803687889151020231709198213752951834097534156853321419009300133041701988088059045538840265627332554454194121024426435019582352173715814900227749253559086664858523212471480396321468257159168804913614969187532210509785588812584841739263332234841113948381329216546405289807839367671066394371976377285491314443468087042916655417085254764424047492227119854758243993637314070997551720795324547265481480108567082864623565773819911308131308207210554182277214230022063294515760720713009700825428955532510",
+                            "ur": null,
+                            "hidden_attributes": [
+                              "master_secret"
+                            ],
+                            "committed_attributes": {}
+                          },
+                          "blinded_ms_correctness_proof": {
+                            "c": "14842005166951621146114950228033228166587445948917220775188417180669817458071",
+                            "v_dash_cap": "525886886600441444565563165744451574453581209783186527553278087235218067249143670252864427868001371270984533684519358843687605475581166282935142905703276466255860485038094631924069785904354326434488518339194078002719755861388964711768508348545543255979806148850295089036263281958934849704765108579167429147052286486914403929145073420962893811107068894159729549508196847548809587052009560288805123173353269086571490649648022184768357155256457950107309654761616752977676620176099125951088465313509009701650195907112862265146926434945766292668030673219665354811192934496571751927032511309995906445544597811901863475749538496709548405261395672321054035313087600543076125543620519913607917930629021139372239900295387614530",
+                            "m_caps": {
+                              "master_secret": "26403860841992559132025470865700367282768662423342071327016182400364926167433347005018624226591156120350434943733972616556764215219552899959288997912500104383298723878965850738210"
+                            },
+                            "r_caps": {}
+                          },
+                          "nonce": "539202924201893565376900"
+                        }
+                      },
+                      "credential": {
+                        "anoncreds": {
+                          "schema_id": "schema:gSl0JkGIcmRif593Q6XYGsJndHGOzm1jWRFa-Lwrz9o",
+                          "cred_def_id": "credential-definition:_p5hLM-uQa1zWnn3tBlSZjLHN3_jrHOq48HZg9x0WNU",
+                          "values": {
+                            "prop2": {
+                              "raw": "Bob",
+                              "encoded": "93006290325627508022776103386395994712401809437930957652111221015872244345185"
+                            },
+                            "prop1": {
+                              "raw": "Alice",
+                              "encoded": "27034640024117331033063128044004318218486816931520886405535659934417438781507"
+                            }
+                          },
+                          "signature": {
+                            "p_credential": {
+                              "m_2": "2911715207125951422480156302046291340123870729973317007174252437265217048587",
+                              "a": "11395635159250760503996843059477894862759042446759456478905609052258966666054297486499529657198356040094543149614125789362925680451864913383442428405747925006507714967572810462914901849679778018440516366649116468683963048348928719272415537003338969559562235424937950447758592924825449445925605210390900510823781990795216551732658029427081784108220873232530576542198769893886026016329571813137791144743390726969182823512920008254774588891824872946440672297966557771368796896826221080416623922702670373253252601697257131639339789773605316559189611430460668913621031924922363795873865565810614212399140440158978630736492",
+                              "e": "259344723055062059907025491480697571938277889515152306249728583105665800713306759149981690559193987143012367913206299323899696942213235956742930090344543936461575196618473935962381",
+                              "v": "8001814536142162607770363548208093772576030885155777393828891920810388269643639795739496611196183494954511428986568490597372615758581717334821354274023290392255038227577524325982981782454790052567586095566736421356705577874795304121932343609694749077725813635912948953884849597222055594720249473114949732531603732043206297827614841392072041631247914713339543298071003341199125553155575573253915872830335388346577731204615565550928758657918974242548635243688870260125103464458103572944515798752393429291619708048708181234777305612276265184799282497088401357918659516303709468557162638343709893397545583781671672656111029322715215691886249339655634731004758885743276863891497637192845057331073900220047078918373696507486114747681960422431667787893756346748792880297182146033915387360507174461962945213023817226802833132149"
+                            },
+                            "r_credential": null
+                          },
+                          "signature_correctness_proof": {
+                            "se": "18071888966807930445969341878476115756105579849496822693675536304985965652940046036953323270875830549601629354090648450651925366597175546789259250284156036563261793522690459846803775756759065096398577328540423797501842695683583228588830053641258351279667129839173861484988969984108220499135535938554712154909596949678407619115337420038902354926030012219508589609561675458487780368202144228827896948708718677481449347040231630306565656593268126349021640222232240758703745752333545546720963799056251898068823571706878796745922121208045372883817285034174020297113979889276046972260648750830806544618009796203666715262922",
+                            "c": "32233748970469592854527577130712976905395946986728509546042467955793436240507"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve the format data associated with a credential exchange",
+        "tags": [
+          "DIDComm Credentials"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "credentialExchangeId",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/RecordId"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      }
+    },
+    "/didcomm/credentials/propose-credential": {
+      "post": {
+        "operationId": "ProposeCredential",
+        "responses": {
+          "200": {
+            "description": "CredentialExchangeRecord",
+            "content": {
+              "application/json": {
+                "schema": {},
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "credentials": [],
+                      "type": "CredentialRecord",
+                      "role": "holder",
+                      "id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+                      "createdAt": "2022-01-01T00:00:00.000Z",
+                      "state": "offer-sent",
+                      "connectionId": "ac6d0fdd-0db8-4f52-8a3d-de7ff8ddc14b",
+                      "threadId": "82701488-b43c-4d7b-9244-4bb204a7ae26",
+                      "credentialAttributes": [],
+                      "protocolVersion": "v1"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Initiate a new credential exchange as holder by sending a propose credential message\nto the connection with a specified connection id.",
+        "tags": [
+          "DIDComm Credentials"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProposeCredentialOptions"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/didcomm/credentials/{credentialExchangeId}/accept-proposal": {
+      "post": {
+        "operationId": "AcceptProposal",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {},
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "credentials": [],
+                      "type": "CredentialRecord",
+                      "role": "holder",
+                      "id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+                      "createdAt": "2022-01-01T00:00:00.000Z",
+                      "state": "offer-sent",
+                      "connectionId": "ac6d0fdd-0db8-4f52-8a3d-de7ff8ddc14b",
+                      "threadId": "82701488-b43c-4d7b-9244-4bb204a7ae26",
+                      "credentialAttributes": [],
+                      "protocolVersion": "v1"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Accept a credential proposal as issuer by sending an accept proposal message\nto the connection associated with the credential exchange record.",
+        "tags": [
+          "DIDComm Credentials"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "credentialExchangeId",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/RecordId"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AcceptCredentialProposalOptions"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/didcomm/credentials/create-offer": {
+      "post": {
+        "operationId": "CreateOffer",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DidCommCredentialsCreateOfferResponse"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "credentialExchange": {
+                        "credentials": [],
+                        "type": "CredentialRecord",
+                        "role": "holder",
+                        "id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+                        "createdAt": "2022-01-01T00:00:00.000Z",
+                        "state": "offer-sent",
+                        "connectionId": "ac6d0fdd-0db8-4f52-8a3d-de7ff8ddc14b",
+                        "threadId": "82701488-b43c-4d7b-9244-4bb204a7ae26",
+                        "credentialAttributes": [],
+                        "protocolVersion": "v1"
+                      },
+                      "message": {
+                        "@id": "134b27f0-9366-4811-a36b-50bacfe57e61",
+                        "@type": "https://didcomm.org/issue-credential/1.0/offer-credential"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Initiate a new credential exchange as issuer by creating a credential offer\nwithout specifying a connection id",
+        "tags": [
+          "DIDComm Credentials"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateOfferOptions"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/didcomm/credentials/offer-credential": {
+      "post": {
+        "operationId": "OfferCredential",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {},
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "credentials": [],
+                      "type": "CredentialRecord",
+                      "role": "holder",
+                      "id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+                      "createdAt": "2022-01-01T00:00:00.000Z",
+                      "state": "offer-sent",
+                      "connectionId": "ac6d0fdd-0db8-4f52-8a3d-de7ff8ddc14b",
+                      "threadId": "82701488-b43c-4d7b-9244-4bb204a7ae26",
+                      "credentialAttributes": [],
+                      "protocolVersion": "v1"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Initiate a new credential exchange as issuer by sending a offer credential message\nto the connection with the specified connection id.",
+        "tags": [
+          "DIDComm Credentials"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OfferCredentialOptions"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/didcomm/credentials/{credentialExchangeId}/accept-offer": {
+      "post": {
+        "operationId": "AcceptOffer",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {},
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "credentials": [],
+                      "type": "CredentialRecord",
+                      "role": "holder",
+                      "id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+                      "createdAt": "2022-01-01T00:00:00.000Z",
+                      "state": "offer-sent",
+                      "connectionId": "ac6d0fdd-0db8-4f52-8a3d-de7ff8ddc14b",
+                      "threadId": "82701488-b43c-4d7b-9244-4bb204a7ae26",
+                      "credentialAttributes": [],
+                      "protocolVersion": "v1"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Accept a credential offer as holder by sending an accept offer message\nto the connection associated with the credential exchange record.",
+        "tags": [
+          "DIDComm Credentials"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "credentialExchangeId",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/RecordId"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AcceptCredentialOfferOptions"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/didcomm/credentials/{credentialExchangeId}/accept-request": {
+      "post": {
+        "operationId": "AcceptRequest",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {},
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "credentials": [],
+                      "type": "CredentialRecord",
+                      "role": "holder",
+                      "id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+                      "createdAt": "2022-01-01T00:00:00.000Z",
+                      "state": "offer-sent",
+                      "connectionId": "ac6d0fdd-0db8-4f52-8a3d-de7ff8ddc14b",
+                      "threadId": "82701488-b43c-4d7b-9244-4bb204a7ae26",
+                      "credentialAttributes": [],
+                      "protocolVersion": "v1"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Accept a credential request as issuer by sending an accept request message\nto the connection associated with the credential exchange record.",
+        "tags": [
+          "DIDComm Credentials"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "credentialExchangeId",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/RecordId"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AcceptCredentialRequestOptions"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/didcomm/credentials/{credentialExchangeId}/accept-credential": {
+      "post": {
+        "operationId": "AcceptCredential",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {},
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "credentials": [],
+                      "type": "CredentialRecord",
+                      "role": "holder",
+                      "id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+                      "createdAt": "2022-01-01T00:00:00.000Z",
+                      "state": "offer-sent",
+                      "connectionId": "ac6d0fdd-0db8-4f52-8a3d-de7ff8ddc14b",
+                      "threadId": "82701488-b43c-4d7b-9244-4bb204a7ae26",
+                      "credentialAttributes": [],
+                      "protocolVersion": "v1"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Accept a credential as holder by sending an accept credential message\nto the connection associated with the credential exchange record.",
+        "tags": [
+          "DIDComm Credentials"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "credentialExchangeId",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/RecordId"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      }
+    },
+    "/didcomm/connections": {
+      "get": {
+        "operationId": "FindConnectionsByQuery",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/DidCommConnectionRecord"
+                  },
+                  "type": "array"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": [
+                      {
+                        "id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+                        "type": "ConnectionRecord",
+                        "createdAt": "2022-01-01T00:00:00.000Z",
+                        "did": "did:peer:1zQmfQh1T3rSqarP2FZ37uKjdQHPKFdVyo2mGiAPHZ8Ep7hv",
+                        "state": "invitation-sent",
+                        "role": "responder",
+                        "invitationDid": "did:peer:2.SeyJzIjoiaHR0cHM6Ly9kYTIzLTg5LTIwLTE2Mi0xNDYubmdyb2suaW8iLCJ0IjoiZGlkLWNvbW11bmljYXRpb24iLCJwcmlvcml0eSI6MCwicmVjaXBpZW50S2V5cyI6WyJkaWQ6a2V5Ono2TWtualg3U1lXRmdHMThCYkNEZHJnemhuQnA0UlhyOGVITHZxQ3FvRXllckxiTiN6Nk1rbmpYN1NZV0ZnRzE4QmJDRGRyZ3pobkJwNFJYcjhlSEx2cUNxb0V5ZXJMYk4iXSwiciI6W119",
+                        "outOfBandId": "edbc89fe-785f-4774-a288-46012486881d"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Find connection record by query",
+        "tags": [
+          "DIDComm Connections"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "outOfBandId",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/RecordId"
+            }
+          },
+          {
+            "in": "query",
+            "name": "alias",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "state",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/DidExchangeState"
+            }
+          },
+          {
+            "in": "query",
+            "name": "did",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/Did"
+            }
+          },
+          {
+            "in": "query",
+            "name": "theirDid",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/Did"
+            }
+          },
+          {
+            "in": "query",
+            "name": "theirLabel",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      }
+    },
+    "/didcomm/connections/{connectionId}": {
+      "get": {
+        "operationId": "GetConnectionById",
+        "responses": {
+          "200": {
+            "description": "ConnectionRecord",
+            "content": {
+              "application/json": {
+                "schema": {},
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+                      "type": "ConnectionRecord",
+                      "createdAt": "2022-01-01T00:00:00.000Z",
+                      "did": "did:peer:1zQmfQh1T3rSqarP2FZ37uKjdQHPKFdVyo2mGiAPHZ8Ep7hv",
+                      "state": "invitation-sent",
+                      "role": "responder",
+                      "invitationDid": "did:peer:2.SeyJzIjoiaHR0cHM6Ly9kYTIzLTg5LTIwLTE2Mi0xNDYubmdyb2suaW8iLCJ0IjoiZGlkLWNvbW11bmljYXRpb24iLCJwcmlvcml0eSI6MCwicmVjaXBpZW50S2V5cyI6WyJkaWQ6a2V5Ono2TWtualg3U1lXRmdHMThCYkNEZHJnemhuQnA0UlhyOGVITHZxQ3FvRXllckxiTiN6Nk1rbmpYN1NZV0ZnRzE4QmJDRGRyZ3pobkJwNFJYcjhlSEx2cUNxb0V5ZXJMYk4iXSwiciI6W119",
+                      "outOfBandId": "edbc89fe-785f-4774-a288-46012486881d"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve connection record by connection id",
+        "tags": [
+          "DIDComm Connections"
+        ],
+        "parameters": [
+          {
+            "description": "Connection identifier",
+            "in": "path",
+            "name": "connectionId",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/RecordId"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteConnection",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "description": "Deletes a connection record from the connection repository.",
+        "tags": [
+          "DIDComm Connections"
+        ],
+        "parameters": [
+          {
+            "description": "Connection identifier",
+            "in": "path",
+            "name": "connectionId",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/RecordId"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      }
+    },
+    "/didcomm/connections/{connectionId}/accept-request": {
+      "post": {
+        "operationId": "AcceptRequest",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {},
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+                      "type": "ConnectionRecord",
+                      "createdAt": "2022-01-01T00:00:00.000Z",
+                      "did": "did:peer:1zQmfQh1T3rSqarP2FZ37uKjdQHPKFdVyo2mGiAPHZ8Ep7hv",
+                      "state": "invitation-sent",
+                      "role": "responder",
+                      "invitationDid": "did:peer:2.SeyJzIjoiaHR0cHM6Ly9kYTIzLTg5LTIwLTE2Mi0xNDYubmdyb2suaW8iLCJ0IjoiZGlkLWNvbW11bmljYXRpb24iLCJwcmlvcml0eSI6MCwicmVjaXBpZW50S2V5cyI6WyJkaWQ6a2V5Ono2TWtualg3U1lXRmdHMThCYkNEZHJnemhuQnA0UlhyOGVITHZxQ3FvRXllckxiTiN6Nk1rbmpYN1NZV0ZnRzE4QmJDRGRyZ3pobkJwNFJYcjhlSEx2cUNxb0V5ZXJMYk4iXSwiciI6W119",
+                      "outOfBandId": "edbc89fe-785f-4774-a288-46012486881d"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Accept a connection request as inviter by sending a connection response message\nfor the connection with the specified connection id.\n\nThis is not needed when auto accepting of connection is enabled.",
+        "tags": [
+          "DIDComm Connections"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "connectionId",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/RecordId"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      }
+    },
+    "/didcomm/connections/{connectionId}/accept-response": {
+      "post": {
+        "operationId": "AcceptResponse",
+        "responses": {
+          "200": {
+            "description": "ConnectionRecord",
+            "content": {
+              "application/json": {
+                "schema": {},
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+                      "type": "ConnectionRecord",
+                      "createdAt": "2022-01-01T00:00:00.000Z",
+                      "did": "did:peer:1zQmfQh1T3rSqarP2FZ37uKjdQHPKFdVyo2mGiAPHZ8Ep7hv",
+                      "state": "invitation-sent",
+                      "role": "responder",
+                      "invitationDid": "did:peer:2.SeyJzIjoiaHR0cHM6Ly9kYTIzLTg5LTIwLTE2Mi0xNDYubmdyb2suaW8iLCJ0IjoiZGlkLWNvbW11bmljYXRpb24iLCJwcmlvcml0eSI6MCwicmVjaXBpZW50S2V5cyI6WyJkaWQ6a2V5Ono2TWtualg3U1lXRmdHMThCYkNEZHJnemhuQnA0UlhyOGVITHZxQ3FvRXllckxiTiN6Nk1rbmpYN1NZV0ZnRzE4QmJDRGRyZ3pobkJwNFJYcjhlSEx2cUNxb0V5ZXJMYk4iXSwiciI6W119",
+                      "outOfBandId": "edbc89fe-785f-4774-a288-46012486881d"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Accept a connection response as invitee by sending a trust ping message\nfor the connection with the specified connection id.\n\nThis is not needed when auto accepting of connection is enabled.",
+        "tags": [
+          "DIDComm Connections"
+        ],
+        "parameters": [
+          {
+            "description": "Connection identifier",
+            "in": "path",
+            "name": "connectionId",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/RecordId"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      }
+    },
+    "/didcomm/basic-messages": {
+      "get": {
+        "operationId": "FindBasicMessagesByQuery",
+        "responses": {
+          "200": {
+            "description": "BasicMessageRecord[]",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/DidCommBasicMessageRecord"
+                  },
+                  "type": "array"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": [
+                      {
+                        "id": "74bcf865-1fdc-45b4-b517-9def02dfd25f",
+                        "createdAt": "2022-08-18T08:38:40.216Z",
+                        "type": "BasicMessageRecord",
+                        "content": "Hello!",
+                        "sentTime": "2022-08-18T08:38:40.216Z",
+                        "connectionId": "2aecf74c-3073-4f98-9acb-92415d096834",
+                        "role": "sender"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve basic messages by connection id",
+        "tags": [
+          "DIDComm Basic Messages"
+        ],
+        "parameters": [
+          {
+            "description": "Connection identifier",
+            "in": "query",
+            "name": "connectionId",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/RecordId"
+            }
+          },
+          {
+            "in": "query",
+            "name": "role",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/BasicMessageRole"
+            }
+          },
+          {
+            "in": "query",
+            "name": "threadId",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/ThreadId"
+            }
+          },
+          {
+            "in": "query",
+            "name": "parentThreadId",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/ThreadId"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      }
+    },
+    "/didcomm/basic-messages/send": {
+      "post": {
+        "operationId": "SendMessage",
+        "responses": {
+          "200": {
+            "description": "BasicMessageRecord",
+            "content": {
+              "application/json": {
+                "schema": {},
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "id": "74bcf865-1fdc-45b4-b517-9def02dfd25f",
+                      "createdAt": "2022-08-18T08:38:40.216Z",
+                      "type": "BasicMessageRecord",
+                      "content": "Hello!",
+                      "sentTime": "2022-08-18T08:38:40.216Z",
+                      "connectionId": "2aecf74c-3073-4f98-9acb-92415d096834",
+                      "role": "sender"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Send a basic message to a connection",
+        "tags": [
+          "DIDComm Basic Messages"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DidCommBasicMessagesSendOptions"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/dids/{did}": {
+      "get": {
+        "operationId": "ResolveDid",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DidResolveSuccessResponse"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "didDocument": {
+                        "@context": [
+                          "https://w3id.org/did/v1",
+                          "https://w3id.org/security/suites/ed25519-2018/v1",
+                          "https://w3id.org/security/suites/x25519-2019/v1"
+                        ],
+                        "id": "did:key:z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL",
+                        "verificationMethod": [
+                          {
+                            "id": "did:key:z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL#z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL",
+                            "type": "Ed25519VerificationKey2018",
+                            "controller": "did:key:z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL",
+                            "publicKeyBase58": "6fioC1zcDPyPEL19pXRS2E4iJ46zH7xP6uSgAaPdwDrx"
+                          }
+                        ],
+                        "authentication": [
+                          "did:key:z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL#z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL"
+                        ],
+                        "assertionMethod": [
+                          "did:key:z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL#z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL"
+                        ],
+                        "capabilityInvocation": [
+                          "did:key:z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL#z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL"
+                        ],
+                        "capabilityDelegation": [
+                          "did:key:z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL#z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL"
+                        ],
+                        "keyAgreement": [
+                          {
+                            "id": "did:key:z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL#z6LSrdqo4M24WRDJj1h2hXxgtDTyzjjKCiyapYVgrhwZAySn",
+                            "type": "X25519KeyAgreementKey2019",
+                            "controller": "did:key:z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL",
+                            "publicKeyBase58": "FxfdY3DCQxVZddKGAtSjZdFW9bCCW7oRwZn1NFJ2Tbg2"
+                          }
+                        ]
+                      },
+                      "didDocumentMetadata": {},
+                      "didResolutionMetadata": {
+                        "contentType": "application/did+ld+json"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Did not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DidResolveFailedResponse"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "didDocument": null,
+                      "didDocumentMetadata": {},
+                      "didResolutionMetadata": {
+                        "error": "notFound",
+                        "message": "DID not found"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Error resolving did",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DidResolveFailedResponse"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "didDocument": null,
+                      "didDocumentMetadata": {},
+                      "didResolutionMetadata": {
+                        "error": "notFound",
+                        "message": "DID not found"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Resolves did and returns did resolution result",
+        "tags": [
+          "Dids"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "did",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      }
+    },
+    "/dids/import": {
+      "post": {
+        "operationId": "ImportDid",
+        "responses": {
+          "201": {
+            "description": "Did imported successfully"
+          }
+        },
+        "description": "Import a did (with optional did document).\n\nIf no did document is provided, the did will be resolved to fetch the did document.",
+        "tags": [
+          "Dids"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DidImportOptions"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/dids/create": {
+      "post": {
+        "operationId": "CreateDid",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DidCreateFinishedResponse"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "didState": {
+                        "did": "did:key:z6MkpGuzuD38tpgZKPfmLmmD8R6gihP9KJhuopMuVvfGzLmc",
+                        "state": "finished",
+                        "didDocument": {
+                          "@context": [
+                            "https://w3id.org/did/v1",
+                            "https://w3id.org/security/suites/ed25519-2018/v1",
+                            "https://w3id.org/security/suites/x25519-2019/v1"
+                          ],
+                          "id": "did:key:z6MkpGuzuD38tpgZKPfmLmmD8R6gihP9KJhuopMuVvfGzLmc",
+                          "verificationMethod": [
+                            {
+                              "id": "did:key:z6MkpGuzuD38tpgZKPfmLmmD8R6gihP9KJhuopMuVvfGzLmc#z6MkpGuzuD38tpgZKPfmLmmD8R6gihP9KJhuopMuVvfGzLmc",
+                              "type": "Ed25519VerificationKey2018",
+                              "controller": "did:key:z6MkpGuzuD38tpgZKPfmLmmD8R6gihP9KJhuopMuVvfGzLmc",
+                              "publicKeyBase58": "ApexJxnhZHC6Ctq4fCoNHKYgu87HuRTZ7oSyfehG57zE"
+                            }
+                          ],
+                          "authentication": [
+                            "did:key:z6MkpGuzuD38tpgZKPfmLmmD8R6gihP9KJhuopMuVvfGzLmc#z6MkpGuzuD38tpgZKPfmLmmD8R6gihP9KJhuopMuVvfGzLmc"
+                          ],
+                          "assertionMethod": [
+                            "did:key:z6MkpGuzuD38tpgZKPfmLmmD8R6gihP9KJhuopMuVvfGzLmc#z6MkpGuzuD38tpgZKPfmLmmD8R6gihP9KJhuopMuVvfGzLmc"
+                          ],
+                          "keyAgreement": [
+                            {
+                              "id": "did:key:z6MkpGuzuD38tpgZKPfmLmmD8R6gihP9KJhuopMuVvfGzLmc#z6LSm5B4fB9NA55xB7PSeMYTMS9sf8uboJvyZBaDLLSZ7Ryd",
+                              "type": "X25519KeyAgreementKey2019",
+                              "controller": "did:key:z6MkpGuzuD38tpgZKPfmLmmD8R6gihP9KJhuopMuVvfGzLmc",
+                              "publicKeyBase58": "APzu8sLW4cND5j1g7i2W2qwPozNV6hkpgCrXqso2Q4Cs"
+                            }
+                          ],
+                          "capabilityInvocation": [
+                            "did:key:z6MkpGuzuD38tpgZKPfmLmmD8R6gihP9KJhuopMuVvfGzLmc#z6MkpGuzuD38tpgZKPfmLmmD8R6gihP9KJhuopMuVvfGzLmc"
+                          ],
+                          "capabilityDelegation": [
+                            "did:key:z6MkpGuzuD38tpgZKPfmLmmD8R6gihP9KJhuopMuVvfGzLmc#z6MkpGuzuD38tpgZKPfmLmmD8R6gihP9KJhuopMuVvfGzLmc"
+                          ]
+                        }
+                      },
+                      "didDocumentMetadata": {},
+                      "didRegistrationMetadata": {}
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Wait for action to complete",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DidCreateWaitResponse"
+                },
+                "examples": {
+                  "Example 1": {}
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Error creating did",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DidCreateFailedResponse"
+                },
+                "examples": {
+                  "Example 1": {}
+                }
+              }
+            }
+          }
+        },
+        "description": "Create a new did.",
+        "tags": [
+          "Dids"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DidCreateOptions"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/anoncreds/schemas/{schemaId}": {
+      "get": {
+        "operationId": "GetSchemaById",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnonCredsGetSchemaSuccessResponse"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "resolutionMetadata": {},
+                      "schemaMetadata": {},
+                      "schemaId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv/anoncreds/v0/SCHEMA/schema-name/1.0",
+                      "schema": {
+                        "issuerId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv",
+                        "name": "schema-name",
+                        "version": "1.0",
+                        "attrNames": [
+                          "age"
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid schemaId or unknown AnonCreds method provided",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnonCredsGetSchemaFailedResponse"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "resolutionMetadata": {
+                        "error": "notFound",
+                        "message": "Schema not found"
+                      },
+                      "schemaMetadata": {},
+                      "schemaId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv/anoncreds/v0/SCHEMA/schema-name/1.0"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Schema not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnonCredsGetSchemaFailedResponse"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "resolutionMetadata": {
+                        "error": "notFound",
+                        "message": "Schema not found"
+                      },
+                      "schemaMetadata": {},
+                      "schemaId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv/anoncreds/v0/SCHEMA/schema-name/1.0"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unknown error retrieving schema",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnonCredsGetSchemaFailedResponse"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "resolutionMetadata": {
+                        "error": "notFound",
+                        "message": "Schema not found"
+                      },
+                      "schemaMetadata": {},
+                      "schemaId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv/anoncreds/v0/SCHEMA/schema-name/1.0"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve schema by schema id",
+        "tags": [
+          "AnonCreds"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "schemaId",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AnonCredsSchemaId"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      }
+    },
+    "/anoncreds/schemas": {
+      "post": {
+        "operationId": "RegisterSchema",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnonCredsRegisterSchemaSuccessResponse"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "registrationMetadata": {},
+                      "schemaMetadata": {},
+                      "schemaState": {
+                        "state": "finished",
+                        "schemaId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv/anoncreds/v0/SCHEMA/schema-name/1.0",
+                        "schema": {
+                          "issuerId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv",
+                          "name": "schema-name",
+                          "version": "1.0",
+                          "attrNames": [
+                            "string"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Wait for action to complete",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnonCredsRegisterSchemaWaitResponse"
+                },
+                "examples": {
+                  "Example 1": {}
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unknown error registering schema",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnonCredsRegisterSchemaFailedResponse"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "registrationMetadata": {},
+                      "schemaMetadata": {},
+                      "schemaState": {
+                        "state": "failed",
+                        "reason": "Unknown error occurred while registering schema",
+                        "schemaId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv/anoncreds/v0/SCHEMA/schema-name/1.0"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Creates a new AnonCreds schema and registers the schema in the AnonCreds registry",
+        "tags": [
+          "AnonCreds"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AnonCredsRegisterSchemaBody"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/anoncreds/credential-definitions/{credentialDefinitionId}": {
+      "get": {
+        "operationId": "GetCredentialDefinitionById",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnonCredsGetCredentialDefinitionSuccessResponse"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "resolutionMetadata": {},
+                      "credentialDefinitionMetadata": {},
+                      "credentialDefinitionId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv/anoncreds/v0/CLAIM_DEF/20/definition",
+                      "credentialDefinition": {
+                        "issuerId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv",
+                        "schemaId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv/anoncreds/v0/SCHEMA/schema-name/1.0",
+                        "type": "CL",
+                        "tag": "definition",
+                        "value": {
+                          "primary": {
+                            "n": "string",
+                            "s": "string",
+                            "r": {
+                              "master_secret": "string",
+                              "string": "string"
+                            },
+                            "rctxt": "string",
+                            "z": "string"
+                          },
+                          "revocation": {
+                            "g": "1 string",
+                            "g_dash": "string",
+                            "h": "string",
+                            "h0": "string",
+                            "h1": "string",
+                            "h2": "string",
+                            "htilde": "string",
+                            "h_cap": "string",
+                            "u": "string",
+                            "pk": "string",
+                            "y": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid credentialDefinitionId or unknown AnonCreds method provided",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnonCredsGetCredentialDefinitionFailedResponse"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "resolutionMetadata": {
+                        "error": "notFound",
+                        "message": "CredentialDefinition not found"
+                      },
+                      "credentialDefinitionMetadata": {},
+                      "credentialDefinitionId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv/anoncreds/v0/CLAIM_DEF/20/definition"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "CredentialDefinition not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnonCredsGetCredentialDefinitionFailedResponse"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "resolutionMetadata": {
+                        "error": "notFound",
+                        "message": "CredentialDefinition not found"
+                      },
+                      "credentialDefinitionMetadata": {},
+                      "credentialDefinitionId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv/anoncreds/v0/CLAIM_DEF/20/definition"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unknown error retrieving credentialDefinition",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnonCredsGetCredentialDefinitionFailedResponse"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "resolutionMetadata": {
+                        "error": "notFound",
+                        "message": "CredentialDefinition not found"
+                      },
+                      "credentialDefinitionMetadata": {},
+                      "credentialDefinitionId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv/anoncreds/v0/CLAIM_DEF/20/definition"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve credentialDefinition by credentialDefinition id",
+        "tags": [
+          "AnonCreds"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "credentialDefinitionId",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AnonCredsCredentialDefinitionId"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      }
+    },
+    "/anoncreds/credential-definitions": {
+      "post": {
+        "operationId": "RegisterCredentialDefinition",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnonCredsRegisterCredentialDefinitionSuccessResponse"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "registrationMetadata": {},
+                      "credentialDefinitionMetadata": {},
+                      "credentialDefinitionState": {
+                        "state": "finished",
+                        "credentialDefinitionId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv/anoncreds/v0/SCHEMA/credentialDefinition-name/1.0",
+                        "credentialDefinition": {
+                          "issuerId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv",
+                          "schemaId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv/anoncreds/v0/SCHEMA/schema-name/1.0",
+                          "type": "CL",
+                          "tag": "definition",
+                          "value": {
+                            "primary": {
+                              "n": "string",
+                              "s": "string",
+                              "r": {
+                                "master_secret": "string",
+                                "string": "string"
+                              },
+                              "rctxt": "string",
+                              "z": "string"
+                            },
+                            "revocation": {
+                              "g": "1 string",
+                              "g_dash": "string",
+                              "h": "string",
+                              "h0": "string",
+                              "h1": "string",
+                              "h2": "string",
+                              "htilde": "string",
+                              "h_cap": "string",
+                              "u": "string",
+                              "pk": "string",
+                              "y": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Wait for action to complete",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnonCredsRegisterCredentialDefinitionWaitResponse"
+                },
+                "examples": {
+                  "Example 1": {}
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unknown error registering credentialDefinition",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnonCredsRegisterCredentialDefinitionFailedResponse"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "registrationMetadata": {},
+                      "credentialDefinitionMetadata": {},
+                      "credentialDefinitionState": {
+                        "state": "failed",
+                        "reason": "Unknown error occurred while registering credentialDefinition",
+                        "credentialDefinitionId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv/anoncreds/v0/SCHEMA/credentialDefinition-name/1.0"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Creates a new AnonCreds credentialDefinition and registers the credentialDefinition in the AnonCreds registry",
+        "tags": [
+          "AnonCreds"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AnonCredsRegisterCredentialDefinitionBody"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agent": {
+      "get": {
+        "operationId": "GetAgentInfo",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentInfo"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "config": {
+                        "label": "Example Agent",
+                        "endpoints": [
+                          "http://localhost:3000"
+                        ]
+                      },
+                      "isInitialized": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve basic agent information",
+        "tags": [
+          "Agent"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/tenant"
+          }
+        ]
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "/"
+    }
+  ],
+  "components": {
+    "examples": {},
+    "headers": {},
+    "requestBodies": {},
+    "responses": {},
+    "schemas": {
+      "Pick_TenantConfig.Exclude_keyofTenantConfig.walletConfig__": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "connectionImageUrl": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "label"
+        ],
+        "type": "object",
+        "description": "From T, pick a set of properties whose keys are in the union K"
+      },
+      "Omit_TenantConfig.walletConfig_": {
+        "$ref": "#/components/schemas/Pick_TenantConfig.Exclude_keyofTenantConfig.walletConfig__",
+        "description": "Construct a type with the properties of T except for those in type K."
+      },
+      "TenantApiConfig": {
+        "$ref": "#/components/schemas/Omit_TenantConfig.walletConfig_"
+      },
+      "RecordId": {
+        "type": "string",
+        "example": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e"
+      },
+      "TenantRecord": {
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/RecordId"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "storageVersion": {
+            "type": "string"
+          },
+          "config": {
+            "$ref": "#/components/schemas/TenantApiConfig"
+          }
+        },
+        "required": [
+          "id",
+          "createdAt",
+          "type",
+          "storageVersion",
+          "config"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "TenantsCreateOptions": {
+        "properties": {
+          "config": {
+            "properties": {
+              "connectionImageUrl": {
+                "type": "string"
+              },
+              "label": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "label"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "config"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "TenantsUpdateOptions": {
+        "properties": {
+          "config": {
+            "properties": {
+              "connectionImageUrl": {
+                "type": "string",
+                "nullable": true
+              },
+              "label": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "PublicVerifierId": {
+        "type": "string",
+        "description": "The public verifier id, used for hosting SIOP / OAuth2 endpoints and metadata"
+      },
+      "OpenId4VcVerifierRecord": {
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/RecordId"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "publicVerifierId": {
+            "$ref": "#/components/schemas/PublicVerifierId"
+          }
+        },
+        "required": [
+          "id",
+          "createdAt",
+          "type",
+          "publicVerifierId"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "OpenId4VcVerifiersCreateOptions": {
+        "properties": {
+          "publicVerifierId": {
+            "$ref": "#/components/schemas/PublicVerifierId"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false,
+        "example": {}
+      },
+      "OpenId4VcVerificationSessionState": {
+        "enum": [
+          "RequestCreated",
+          "RequestUriRetrieved",
+          "ResponseVerified",
+          "Error"
+        ],
+        "type": "string"
+      },
+      "ICredentialContext": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "did": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "Record_string.any_": {
+        "properties": {},
+        "additionalProperties": {},
+        "type": "object",
+        "description": "Construct a type with a set of properties K of type T"
+      },
+      "AdditionalClaims": {
+        "$ref": "#/components/schemas/Record_string.any_"
+      },
+      "ICredentialContextType": {
+        "anyOf": [
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ICredentialContext"
+              },
+              {
+                "$ref": "#/components/schemas/AdditionalClaims"
+              }
+            ]
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "ICredentialSchema": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ICredentialSchemaType": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/ICredentialSchema"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "IIssuerId": {
+        "type": "string"
+      },
+      "IIssuer": {
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "ICredentialSubject": {
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ICredentialStatus": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "type"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ICredential": {
+        "properties": {
+          "@context": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ICredentialContextType"
+              },
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ICredentialContextType"
+                },
+                "type": "array"
+              }
+            ]
+          },
+          "type": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "credentialSchema": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ICredentialSchemaType"
+              },
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ICredentialSchemaType"
+                },
+                "type": "array"
+              }
+            ]
+          },
+          "issuer": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/IIssuerId"
+              },
+              {
+                "$ref": "#/components/schemas/IIssuer"
+              }
+            ]
+          },
+          "issuanceDate": {
+            "type": "string"
+          },
+          "credentialSubject": {
+            "anyOf": [
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ICredentialSubject"
+                  },
+                  {
+                    "$ref": "#/components/schemas/AdditionalClaims"
+                  }
+                ]
+              },
+              {
+                "items": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/ICredentialSubject"
+                    },
+                    {
+                      "$ref": "#/components/schemas/AdditionalClaims"
+                    }
+                  ]
+                },
+                "type": "array"
+              }
+            ]
+          },
+          "expirationDate": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "credentialStatus": {
+            "$ref": "#/components/schemas/ICredentialStatus"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "@context",
+          "type",
+          "issuer",
+          "issuanceDate",
+          "credentialSubject"
+        ],
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "IProofType": {
+        "enum": [
+          "Ed25519Signature2018",
+          "Ed25519Signature2020",
+          "EcdsaSecp256k1Signature2019",
+          "EcdsaSecp256k1RecoverySignature2020",
+          "JsonWebSignature2020",
+          "RsaSignature2018",
+          "GpgSignature2020",
+          "JcsEd25519Signature2020",
+          "BbsBlsSignatureProof2020",
+          "BbsBlsBoundSignatureProof2020",
+          "JwtProof2020"
+        ],
+        "type": "string"
+      },
+      "IProofPurpose": {
+        "enum": [
+          "verificationMethod",
+          "assertionMethod",
+          "authentication",
+          "keyAgreement",
+          "contactAgreement",
+          "capabilityInvocation",
+          "capabilityDelegation"
+        ],
+        "type": "string"
+      },
+      "IProof": {
+        "properties": {
+          "type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/IProofType"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "created": {
+            "type": "string"
+          },
+          "proofPurpose": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/IProofPurpose"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "verificationMethod": {
+            "type": "string"
+          },
+          "challenge": {
+            "type": "string"
+          },
+          "domain": {
+            "type": "string"
+          },
+          "proofValue": {
+            "type": "string"
+          },
+          "jws": {
+            "type": "string"
+          },
+          "jwt": {
+            "type": "string"
+          },
+          "nonce": {
+            "type": "string"
+          },
+          "requiredRevealStatements": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "type",
+          "created",
+          "proofPurpose",
+          "verificationMethod"
+        ],
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "IHasProof": {
+        "properties": {
+          "proof": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/IProof"
+              },
+              {
+                "items": {
+                  "$ref": "#/components/schemas/IProof"
+                },
+                "type": "array"
+              }
+            ]
+          }
+        },
+        "required": [
+          "proof"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "IVerifiableCredential": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ICredential"
+          },
+          {
+            "$ref": "#/components/schemas/IHasProof"
+          }
+        ]
+      },
+      "CompactJWT": {
+        "type": "string",
+        "description": "Represents a Json Web Token in compact form."
+      },
+      "W3CVerifiableCredential": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/IVerifiableCredential"
+          },
+          {
+            "$ref": "#/components/schemas/CompactJWT"
+          }
+        ],
+        "description": "Represents a signed Verifiable Credential (includes proof), in either JSON, compact JWT or compact SD-JWT VC format.\nSee {@link https://www.w3.org/TR/vc-data-model/#credentials VC data model}\nSee {@link https://www.w3.org/TR/vc-data-model/#proof-formats proof formats}"
+      },
+      "Descriptor": {
+        "description": "descriptor map laying out the structure of the presentation submission.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "ID to identify the descriptor from Presentation Definition Input Descriptor it coresponds to."
+          },
+          "path": {
+            "type": "string",
+            "description": "The path where the verifiable credential is located in the presentation submission json"
+          },
+          "path_nested": {
+            "$ref": "#/components/schemas/Descriptor"
+          },
+          "format": {
+            "type": "string",
+            "description": "The Proof or JWT algorith that the proof is in"
+          }
+        },
+        "required": [
+          "id",
+          "path",
+          "format"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "PresentationSubmission": {
+        "description": "It expresses how the inputs are presented as proofs to a Verifier.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "A UUID or some other unique ID to identify this Presentation Submission"
+          },
+          "definition_id": {
+            "type": "string",
+            "description": "A UUID or some other unique ID to identify this Presentation Definition"
+          },
+          "descriptor_map": {
+            "items": {
+              "$ref": "#/components/schemas/Descriptor"
+            },
+            "type": "array",
+            "description": "List of descriptors of how the claims are being mapped to presentation definition"
+          }
+        },
+        "required": [
+          "id",
+          "definition_id",
+          "descriptor_map"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "IPresentation": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "@context": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ICredentialContextType"
+              },
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ICredentialContextType"
+                },
+                "type": "array"
+              }
+            ]
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            ]
+          },
+          "verifiableCredential": {
+            "items": {
+              "$ref": "#/components/schemas/W3CVerifiableCredential"
+            },
+            "type": "array"
+          },
+          "presentation_submission": {
+            "$ref": "#/components/schemas/PresentationSubmission"
+          },
+          "holder": {
+            "type": "string"
+          },
+          "verifier": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "@context"
+        ],
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "IVerifiablePresentation": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/IPresentation"
+          },
+          {
+            "$ref": "#/components/schemas/IHasProof"
+          }
+        ]
+      },
+      "W3CVerifiablePresentation": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/IVerifiablePresentation"
+          },
+          {
+            "$ref": "#/components/schemas/CompactJWT"
+          }
+        ],
+        "description": "Represents a signed Verifiable Presentation (includes proof), in either JSON or compact JWT format.\nSee {@link https://www.w3.org/TR/vc-data-model/#presentations VC data model}\nSee {@link https://www.w3.org/TR/vc-data-model/#proof-formats proof formats}"
+      },
+      "CompactSdJwtVc": {
+        "type": "string",
+        "description": "Represents a selective disclosure JWT vc in compact form."
+      },
+      "AuthorizationResponsePayload": {
+        "properties": {
+          "access_token": {
+            "type": "string"
+          },
+          "token_type": {
+            "type": "string"
+          },
+          "refresh_token": {
+            "type": "string"
+          },
+          "expires_in": {
+            "type": "number",
+            "format": "double"
+          },
+          "state": {
+            "type": "string"
+          },
+          "id_token": {
+            "type": "string"
+          },
+          "vp_token": {
+            "anyOf": [
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/W3CVerifiablePresentation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/CompactSdJwtVc"
+                    }
+                  ]
+                },
+                "type": "array"
+              },
+              {
+                "$ref": "#/components/schemas/W3CVerifiablePresentation"
+              },
+              {
+                "$ref": "#/components/schemas/CompactSdJwtVc"
+              }
+            ]
+          },
+          "presentation_submission": {
+            "$ref": "#/components/schemas/PresentationSubmission"
+          },
+          "verifiedData": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/IPresentation"
+              },
+              {
+                "$ref": "#/components/schemas/AdditionalClaims"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "OpenId4VcSiopAuthorizationResponsePayload": {
+        "$ref": "#/components/schemas/AuthorizationResponsePayload"
+      },
+      "OpenId4VcVerificationSessionRecord": {
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/RecordId"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "publicVerifierId": {
+            "$ref": "#/components/schemas/PublicVerifierId"
+          },
+          "state": {
+            "$ref": "#/components/schemas/OpenId4VcVerificationSessionState",
+            "description": "The state of the verification session."
+          },
+          "errorMessage": {
+            "type": "string",
+            "description": "Optional error message of the error that occurred during the verification session. Will be set when state is {@link OpenId4VcVerificationSessionState.Error}"
+          },
+          "authorizationRequestJwt": {
+            "type": "string",
+            "description": "The signed JWT containing the authorization request"
+          },
+          "authorizationRequestUri": {
+            "type": "string",
+            "description": "URI of the authorization request. This is the url that can be used to\nretrieve the authorization request"
+          },
+          "authorizationResponsePayload": {
+            "$ref": "#/components/schemas/OpenId4VcSiopAuthorizationResponsePayload",
+            "description": "The payload of the received authorization response"
+          }
+        },
+        "required": [
+          "id",
+          "createdAt",
+          "type",
+          "publicVerifierId",
+          "state",
+          "authorizationRequestJwt",
+          "authorizationRequestUri"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "OpenId4VcVerificationSessionsCreateRequestResponse": {
+        "properties": {
+          "verificationSession": {
+            "$ref": "#/components/schemas/OpenId4VcVerificationSessionRecord"
+          },
+          "authorizationRequest": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "verificationSession",
+          "authorizationRequest"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "OpenId4VcJwtIssuerDid": {
+        "properties": {
+          "method": {
+            "type": "string",
+            "enum": [
+              "did"
+            ],
+            "nullable": false
+          },
+          "didUrl": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "method",
+          "didUrl"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "OpenId4VcJwtIssuer": {
+        "$ref": "#/components/schemas/OpenId4VcJwtIssuerDid"
+      },
+      "JwtObject": {
+        "properties": {
+          "alg": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "alg"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "LdpObject": {
+        "properties": {
+          "proof_type": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "proof_type"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "DiObject": {
+        "properties": {
+          "proof_type": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "cryptosuite": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "proof_type",
+          "cryptosuite"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "SdJwtObject": {
+        "properties": {
+          "undefined": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "Format": {
+        "properties": {
+          "jwt": {
+            "$ref": "#/components/schemas/JwtObject"
+          },
+          "jwt_vc": {
+            "$ref": "#/components/schemas/JwtObject"
+          },
+          "jwt_vc_json": {
+            "$ref": "#/components/schemas/JwtObject"
+          },
+          "jwt_vp": {
+            "$ref": "#/components/schemas/JwtObject"
+          },
+          "jwt_vp_json": {
+            "$ref": "#/components/schemas/JwtObject"
+          },
+          "ldp": {
+            "$ref": "#/components/schemas/LdpObject"
+          },
+          "ldp_vc": {
+            "$ref": "#/components/schemas/LdpObject"
+          },
+          "ldp_vp": {
+            "$ref": "#/components/schemas/LdpObject"
+          },
+          "di": {
+            "$ref": "#/components/schemas/DiObject"
+          },
+          "di_vc": {
+            "$ref": "#/components/schemas/DiObject"
+          },
+          "di_vp": {
+            "$ref": "#/components/schemas/DiObject"
+          },
+          "undefined": {
+            "$ref": "#/components/schemas/SdJwtObject"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "Rules": {
+        "type": "string",
+        "enum": [
+          "all",
+          "pick"
+        ]
+      },
+      "SubmissionRequirement": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "purpose": {
+            "type": "string"
+          },
+          "rule": {
+            "$ref": "#/components/schemas/Rules"
+          },
+          "count": {
+            "type": "number",
+            "format": "double"
+          },
+          "min": {
+            "type": "number",
+            "format": "double"
+          },
+          "max": {
+            "type": "number",
+            "format": "double"
+          },
+          "from": {
+            "type": "string"
+          },
+          "from_nested": {
+            "items": {
+              "$ref": "#/components/schemas/SubmissionRequirement"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "rule"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "Issuance": {
+        "properties": {
+          "manifest": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "Optionality": {
+        "type": "string",
+        "enum": [
+          "required",
+          "preferred"
+        ]
+      },
+      "Directives": {
+        "type": "string",
+        "enum": [
+          "required",
+          "allowed",
+          "disallowed"
+        ]
+      },
+      "PdStatus": {
+        "properties": {
+          "directive": {
+            "$ref": "#/components/schemas/Directives"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "Statuses": {
+        "properties": {
+          "active": {
+            "$ref": "#/components/schemas/PdStatus"
+          },
+          "suspended": {
+            "$ref": "#/components/schemas/PdStatus"
+          },
+          "revoked": {
+            "$ref": "#/components/schemas/PdStatus"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "OneOfNumberString": {
+        "anyOf": [
+          {
+            "type": "number",
+            "format": "double"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "FilterV2Base": {
+        "properties": {
+          "const": {
+            "$ref": "#/components/schemas/OneOfNumberString"
+          },
+          "enum": {
+            "items": {
+              "$ref": "#/components/schemas/OneOfNumberString"
+            },
+            "type": "array"
+          },
+          "exclusiveMinimum": {
+            "$ref": "#/components/schemas/OneOfNumberString"
+          },
+          "exclusiveMaximum": {
+            "$ref": "#/components/schemas/OneOfNumberString"
+          },
+          "format": {
+            "type": "string"
+          },
+          "formatMaximum": {
+            "type": "string"
+          },
+          "formatMinimum": {
+            "type": "string"
+          },
+          "formatExclusiveMaximum": {
+            "type": "string"
+          },
+          "formatExclusiveMinimum": {
+            "type": "string"
+          },
+          "minLength": {
+            "type": "number",
+            "format": "double"
+          },
+          "maxLength": {
+            "type": "number",
+            "format": "double"
+          },
+          "minimum": {
+            "$ref": "#/components/schemas/OneOfNumberString"
+          },
+          "maximum": {
+            "$ref": "#/components/schemas/OneOfNumberString"
+          },
+          "not": {
+            "additionalProperties": false,
+            "type": "object"
+          },
+          "pattern": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "contains": {
+            "$ref": "#/components/schemas/FilterV2Base"
+          },
+          "items": {
+            "$ref": "#/components/schemas/FilterV2BaseItems"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "FilterV2BaseItems": {
+        "properties": {
+          "const": {
+            "$ref": "#/components/schemas/OneOfNumberString"
+          },
+          "enum": {
+            "items": {
+              "$ref": "#/components/schemas/OneOfNumberString"
+            },
+            "type": "array"
+          },
+          "exclusiveMinimum": {
+            "$ref": "#/components/schemas/OneOfNumberString"
+          },
+          "exclusiveMaximum": {
+            "$ref": "#/components/schemas/OneOfNumberString"
+          },
+          "format": {
+            "type": "string"
+          },
+          "formatMaximum": {
+            "type": "string"
+          },
+          "formatMinimum": {
+            "type": "string"
+          },
+          "formatExclusiveMaximum": {
+            "type": "string"
+          },
+          "formatExclusiveMinimum": {
+            "type": "string"
+          },
+          "minLength": {
+            "type": "number",
+            "format": "double"
+          },
+          "maxLength": {
+            "type": "number",
+            "format": "double"
+          },
+          "minimum": {
+            "$ref": "#/components/schemas/OneOfNumberString"
+          },
+          "maximum": {
+            "$ref": "#/components/schemas/OneOfNumberString"
+          },
+          "not": {
+            "additionalProperties": false,
+            "type": "object"
+          },
+          "pattern": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "contains": {
+            "$ref": "#/components/schemas/FilterV2Base"
+          },
+          "items": {
+            "$ref": "#/components/schemas/FilterV2BaseItems"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "FilterV2": {
+        "properties": {
+          "const": {
+            "$ref": "#/components/schemas/OneOfNumberString"
+          },
+          "enum": {
+            "items": {
+              "$ref": "#/components/schemas/OneOfNumberString"
+            },
+            "type": "array"
+          },
+          "exclusiveMinimum": {
+            "$ref": "#/components/schemas/OneOfNumberString"
+          },
+          "exclusiveMaximum": {
+            "$ref": "#/components/schemas/OneOfNumberString"
+          },
+          "format": {
+            "type": "string"
+          },
+          "formatMaximum": {
+            "type": "string"
+          },
+          "formatMinimum": {
+            "type": "string"
+          },
+          "formatExclusiveMaximum": {
+            "type": "string"
+          },
+          "formatExclusiveMinimum": {
+            "type": "string"
+          },
+          "minLength": {
+            "type": "number",
+            "format": "double"
+          },
+          "maxLength": {
+            "type": "number",
+            "format": "double"
+          },
+          "minimum": {
+            "$ref": "#/components/schemas/OneOfNumberString"
+          },
+          "maximum": {
+            "$ref": "#/components/schemas/OneOfNumberString"
+          },
+          "not": {
+            "additionalProperties": false,
+            "type": "object"
+          },
+          "pattern": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "contains": {
+            "$ref": "#/components/schemas/FilterV2Base"
+          },
+          "items": {
+            "$ref": "#/components/schemas/FilterV2BaseItems"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "FieldV2": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "path": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "purpose": {
+            "type": "string"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/FilterV2"
+          },
+          "predicate": {
+            "$ref": "#/components/schemas/Optionality"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "HolderSubject": {
+        "properties": {
+          "field_id": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "directive": {
+            "$ref": "#/components/schemas/Optionality"
+          }
+        },
+        "required": [
+          "field_id",
+          "directive"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ConstraintsV2": {
+        "properties": {
+          "limit_disclosure": {
+            "$ref": "#/components/schemas/Optionality"
+          },
+          "statuses": {
+            "$ref": "#/components/schemas/Statuses"
+          },
+          "fields": {
+            "items": {
+              "$ref": "#/components/schemas/FieldV2"
+            },
+            "type": "array"
+          },
+          "subject_is_issuer": {
+            "$ref": "#/components/schemas/Optionality"
+          },
+          "is_holder": {
+            "items": {
+              "$ref": "#/components/schemas/HolderSubject"
+            },
+            "type": "array"
+          },
+          "same_subject": {
+            "items": {
+              "$ref": "#/components/schemas/HolderSubject"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "InputDescriptorV2": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "purpose": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/components/schemas/Format"
+          },
+          "group": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "issuance": {
+            "items": {
+              "$ref": "#/components/schemas/Issuance"
+            },
+            "type": "array"
+          },
+          "constraints": {
+            "$ref": "#/components/schemas/ConstraintsV2"
+          }
+        },
+        "required": [
+          "id",
+          "constraints"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "PresentationDefinitionV2": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "purpose": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/components/schemas/Format"
+          },
+          "submission_requirements": {
+            "items": {
+              "$ref": "#/components/schemas/SubmissionRequirement"
+            },
+            "type": "array"
+          },
+          "input_descriptors": {
+            "items": {
+              "$ref": "#/components/schemas/InputDescriptorV2"
+            },
+            "type": "array"
+          },
+          "frame": {
+            "additionalProperties": false,
+            "type": "object"
+          }
+        },
+        "required": [
+          "id",
+          "input_descriptors"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "DifPresentationExchangeDefinitionV2": {
+        "$ref": "#/components/schemas/PresentationDefinitionV2"
+      },
+      "OpenId4VcVerificationSessionsCreateRequestOptions": {
+        "properties": {
+          "requestSigner": {
+            "$ref": "#/components/schemas/OpenId4VcJwtIssuer",
+            "description": "Signing information for the request JWT. This will be used to sign the request JWT\nand to set the client_id for registration of client_metadata."
+          },
+          "presentationExchange": {
+            "properties": {
+              "definition": {
+                "$ref": "#/components/schemas/DifPresentationExchangeDefinitionV2"
+              }
+            },
+            "required": [
+              "definition"
+            ],
+            "type": "object",
+            "description": "A DIF Presentation Definition (v2) can be provided to request a Verifiable Presentation using OpenID4VP."
+          },
+          "publicVerifierId": {
+            "$ref": "#/components/schemas/PublicVerifierId"
+          }
+        },
+        "required": [
+          "requestSigner",
+          "publicVerifierId"
+        ],
+        "type": "object",
+        "additionalProperties": false,
+        "example": {
+          "publicVerifierId": "1ab30c0e-1adb-4f01-90e8-cfd425c0a311",
+          "requestSigner": {
+            "method": "did",
+            "didUrl": "did:key:z6MkgViwfstCL1L9i8tgsdAYEu5A62W5mA9DcmSygVVVLFuU#z6MkgViwfstCL1L9i8tgsdAYEu5A62W5mA9DcmSygVVVLFuU"
+          },
+          "presentationExchange": {
+            "definition": {
+              "id": "73797b0c-dae6-46a7-9700-7850855fee22",
+              "name": "Example Presentation Definition",
+              "input_descriptors": [
+                {
+                  "id": "64125742-8b6c-422e-82cd-1beb5123ee8f",
+                  "constraints": {
+                    "limit_disclosure": "required",
+                    "fields": [
+                      {
+                        "path": [
+                          "$.age.over_18"
+                        ],
+                        "filter": {
+                          "type": "boolean"
+                        }
+                      }
+                    ]
+                  },
+                  "name": "Requested Sd Jwt Example Credential",
+                  "purpose": "To provide an example of requesting a credential"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "ResponseIss.SELF_ISSUED_V2": {
+        "enum": [
+          "https://self-issued.me/v2"
+        ],
+        "type": "string"
+      },
+      "IDTokenPayload": {
+        "properties": {
+          "iss": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ResponseIss.SELF_ISSUED_V2"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "sub": {
+            "type": "string"
+          },
+          "aud": {
+            "type": "string"
+          },
+          "iat": {
+            "type": "number",
+            "format": "double"
+          },
+          "nbf": {
+            "type": "number",
+            "format": "double"
+          },
+          "type": {
+            "type": "string"
+          },
+          "exp": {
+            "type": "number",
+            "format": "double"
+          },
+          "rexp": {
+            "type": "number",
+            "format": "double"
+          },
+          "jti": {
+            "type": "string"
+          },
+          "auth_time": {
+            "type": "number",
+            "format": "double"
+          },
+          "nonce": {
+            "type": "string"
+          },
+          "_vp_token": {
+            "properties": {
+              "presentation_submission": {
+                "$ref": "#/components/schemas/PresentationSubmission"
+              }
+            },
+            "required": [
+              "presentation_submission"
+            ],
+            "type": "object"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "OpenId4VcSiopIdTokenPayload": {
+        "$ref": "#/components/schemas/IDTokenPayload"
+      },
+      "Schema": {
+        "properties": {
+          "uri": {
+            "type": "string"
+          },
+          "required": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "uri"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "FilterV1": {
+        "properties": {
+          "const": {
+            "$ref": "#/components/schemas/OneOfNumberString"
+          },
+          "enum": {
+            "items": {
+              "$ref": "#/components/schemas/OneOfNumberString"
+            },
+            "type": "array"
+          },
+          "exclusiveMinimum": {
+            "$ref": "#/components/schemas/OneOfNumberString"
+          },
+          "exclusiveMaximum": {
+            "$ref": "#/components/schemas/OneOfNumberString"
+          },
+          "format": {
+            "type": "string"
+          },
+          "minLength": {
+            "type": "number",
+            "format": "double"
+          },
+          "maxLength": {
+            "type": "number",
+            "format": "double"
+          },
+          "minimum": {
+            "$ref": "#/components/schemas/OneOfNumberString"
+          },
+          "maximum": {
+            "$ref": "#/components/schemas/OneOfNumberString"
+          },
+          "not": {
+            "additionalProperties": false,
+            "type": "object"
+          },
+          "pattern": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "FieldV1": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "path": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "purpose": {
+            "type": "string"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/FilterV1"
+          },
+          "predicate": {
+            "$ref": "#/components/schemas/Optionality"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ConstraintsV1": {
+        "properties": {
+          "limit_disclosure": {
+            "$ref": "#/components/schemas/Optionality"
+          },
+          "statuses": {
+            "$ref": "#/components/schemas/Statuses"
+          },
+          "fields": {
+            "items": {
+              "$ref": "#/components/schemas/FieldV1"
+            },
+            "type": "array"
+          },
+          "subject_is_issuer": {
+            "$ref": "#/components/schemas/Optionality"
+          },
+          "is_holder": {
+            "items": {
+              "$ref": "#/components/schemas/HolderSubject"
+            },
+            "type": "array"
+          },
+          "same_subject": {
+            "items": {
+              "$ref": "#/components/schemas/HolderSubject"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "InputDescriptorV1": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "purpose": {
+            "type": "string"
+          },
+          "group": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "schema": {
+            "items": {
+              "$ref": "#/components/schemas/Schema"
+            },
+            "type": "array"
+          },
+          "issuance": {
+            "items": {
+              "$ref": "#/components/schemas/Issuance"
+            },
+            "type": "array"
+          },
+          "constraints": {
+            "$ref": "#/components/schemas/ConstraintsV1"
+          }
+        },
+        "required": [
+          "id",
+          "schema"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "PresentationDefinitionV1": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "purpose": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/components/schemas/Format"
+          },
+          "submission_requirements": {
+            "items": {
+              "$ref": "#/components/schemas/SubmissionRequirement"
+            },
+            "type": "array"
+          },
+          "input_descriptors": {
+            "items": {
+              "$ref": "#/components/schemas/InputDescriptorV1"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "id",
+          "input_descriptors"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "DifPresentationExchangeDefinition": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/PresentationDefinitionV1"
+          },
+          {
+            "$ref": "#/components/schemas/PresentationDefinitionV2"
+          }
+        ]
+      },
+      "ClaimFormat.SdJwtVc": {
+        "enum": [
+          "vc+sd-jwt"
+        ],
+        "type": "string"
+      },
+      "JwtPayloadJson": {
+        "properties": {
+          "iss": {
+            "type": "string"
+          },
+          "sub": {
+            "type": "string"
+          },
+          "aud": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            ]
+          },
+          "exp": {
+            "type": "number",
+            "format": "double"
+          },
+          "nbf": {
+            "type": "number",
+            "format": "double"
+          },
+          "iat": {
+            "type": "number",
+            "format": "double"
+          },
+          "jti": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "JwkJson": {
+        "properties": {
+          "kty": {
+            "type": "string"
+          },
+          "use": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kty"
+        ],
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "JwtHeader": {
+        "properties": {
+          "alg": {
+            "type": "string"
+          },
+          "kid": {
+            "type": "string"
+          },
+          "jwk": {
+            "$ref": "#/components/schemas/JwkJson"
+          }
+        },
+        "required": [
+          "alg"
+        ],
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "ClaimFormat.JwtVp": {
+        "enum": [
+          "jwt_vp"
+        ],
+        "type": "string"
+      },
+      "JsonObject": {
+        "properties": {},
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/JsonValue"
+        }
+      },
+      "JsonValue": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number",
+            "format": "double"
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "$ref": "#/components/schemas/JsonObject"
+          },
+          {
+            "$ref": "#/components/schemas/JsonArray"
+          }
+        ],
+        "nullable": true
+      },
+      "JsonArray": {
+        "items": {
+          "$ref": "#/components/schemas/JsonValue"
+        },
+        "type": "array"
+      },
+      "SingleOrArray_JsonObject_": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/JsonObject"
+          },
+          {
+            "items": {
+              "$ref": "#/components/schemas/JsonObject"
+            },
+            "type": "array"
+          }
+        ]
+      },
+      "W3cJsonCredential": {
+        "properties": {
+          "@context": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "issuer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            ]
+          },
+          "issuanceDate": {
+            "type": "string"
+          },
+          "expirationDate": {
+            "type": "string"
+          },
+          "credentialSubject": {
+            "$ref": "#/components/schemas/SingleOrArray_JsonObject_"
+          }
+        },
+        "required": [
+          "@context",
+          "type",
+          "issuer",
+          "issuanceDate",
+          "credentialSubject"
+        ],
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "W3cJsonPresentation": {
+        "properties": {
+          "@context": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "holder": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            ]
+          },
+          "verifiableCredential": {
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/W3cJsonCredential"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "@context",
+          "type",
+          "holder",
+          "verifiableCredential"
+        ],
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "ClaimFormat.LdpVp": {
+        "enum": [
+          "ldp_vp"
+        ],
+        "type": "string"
+      },
+      "OpenId4VcVerificationSessionsGetVerifiedAuthorizationResponseResponse": {
+        "description": "Either `idToken` and/or `presentationExchange` will be present, but not none.",
+        "properties": {
+          "idToken": {
+            "properties": {
+              "payload": {
+                "$ref": "#/components/schemas/OpenId4VcSiopIdTokenPayload"
+              }
+            },
+            "required": [
+              "payload"
+            ],
+            "type": "object"
+          },
+          "presentationExchange": {
+            "properties": {
+              "presentations": {
+                "items": {
+                  "anyOf": [
+                    {
+                      "properties": {
+                        "header": {
+                          "$ref": "#/components/schemas/JwtHeader"
+                        },
+                        "signedPayload": {
+                          "$ref": "#/components/schemas/JwtPayloadJson"
+                        },
+                        "vcPayload": {
+                          "$ref": "#/components/schemas/JwtPayloadJson"
+                        },
+                        "encoded": {
+                          "type": "string"
+                        },
+                        "format": {
+                          "$ref": "#/components/schemas/ClaimFormat.SdJwtVc"
+                        }
+                      },
+                      "required": [
+                        "header",
+                        "signedPayload",
+                        "vcPayload",
+                        "encoded",
+                        "format"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "header": {
+                          "$ref": "#/components/schemas/JwtHeader"
+                        },
+                        "signedPayload": {
+                          "$ref": "#/components/schemas/JwtPayloadJson"
+                        },
+                        "vcPayload": {
+                          "$ref": "#/components/schemas/W3cJsonPresentation"
+                        },
+                        "encoded": {
+                          "type": "string"
+                        },
+                        "format": {
+                          "$ref": "#/components/schemas/ClaimFormat.JwtVp"
+                        }
+                      },
+                      "required": [
+                        "header",
+                        "signedPayload",
+                        "vcPayload",
+                        "encoded",
+                        "format"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "vcPayload": {
+                          "$ref": "#/components/schemas/W3cJsonPresentation"
+                        },
+                        "encoded": {
+                          "$ref": "#/components/schemas/W3cJsonPresentation"
+                        },
+                        "format": {
+                          "$ref": "#/components/schemas/ClaimFormat.LdpVp"
+                        }
+                      },
+                      "required": [
+                        "vcPayload",
+                        "encoded",
+                        "format"
+                      ],
+                      "type": "object"
+                    }
+                  ]
+                },
+                "type": "array"
+              },
+              "definition": {
+                "$ref": "#/components/schemas/DifPresentationExchangeDefinition"
+              },
+              "submission": {
+                "$ref": "#/components/schemas/PresentationSubmission"
+              }
+            },
+            "required": [
+              "presentations",
+              "definition",
+              "submission"
+            ],
+            "type": "object"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "PublicIssuerId": {
+        "type": "string",
+        "description": "The public issuer id, used for hosting OpenID4VCI metadata and endpoints"
+      },
+      "CredentialSupportedBrief": {
+        "properties": {
+          "cryptographic_binding_methods_supported": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "cryptographic_suites_supported": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "OID4VCICredentialFormat": {
+        "type": "string",
+        "enum": [
+          "jwt_vc_json",
+          "jwt_vc_json-ld",
+          "ldp_vc",
+          "vc+sd-jwt",
+          "jwt_vc"
+        ]
+      },
+      "NameAndLocale": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "locale": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "ImageInfo": {
+        "description": "Important Note: please be aware that these Common interfaces are based on versions v1_0.11 and v1_0.09",
+        "properties": {
+          "url": {
+            "type": "string"
+          },
+          "alt_text": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "LogoAndColor": {
+        "properties": {
+          "logo": {
+            "$ref": "#/components/schemas/ImageInfo"
+          },
+          "description": {
+            "type": "string"
+          },
+          "background_color": {
+            "type": "string"
+          },
+          "text_color": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "CredentialsSupportedDisplay": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/NameAndLocale"
+          },
+          {
+            "$ref": "#/components/schemas/LogoAndColor"
+          },
+          {
+            "properties": {
+              "background_image": {
+                "$ref": "#/components/schemas/ImageInfo"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "CommonCredentialSupported": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CredentialSupportedBrief"
+          },
+          {
+            "properties": {
+              "display": {
+                "items": {
+                  "$ref": "#/components/schemas/CredentialsSupportedDisplay"
+                },
+                "type": "array"
+              },
+              "id": {
+                "type": "string"
+              },
+              "format": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/OID4VCICredentialFormat"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "format"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "CredentialSubjectDisplay": {
+        "properties": {
+          "mandatory": {
+            "type": "boolean"
+          },
+          "value_type": {
+            "type": "string"
+          },
+          "display": {
+            "items": {
+              "$ref": "#/components/schemas/NameAndLocale"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "IssuerCredentialSubjectDisplay": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CredentialSubjectDisplay"
+          },
+          {
+            "properties": {},
+            "additionalProperties": {
+              "$ref": "#/components/schemas/CredentialSubjectDisplay"
+            },
+            "type": "object"
+          }
+        ]
+      },
+      "IssuerCredentialSubject": {
+        "properties": {},
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/IssuerCredentialSubjectDisplay"
+        }
+      },
+      "CredentialSupportedJwtVcJson": {
+        "properties": {
+          "types": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "credentialSubject": {
+            "$ref": "#/components/schemas/IssuerCredentialSubject"
+          },
+          "order": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "format": {
+            "type": "string",
+            "enum": [
+              "jwt_vc_json",
+              "jwt_vc"
+            ]
+          }
+        },
+        "required": [
+          "types",
+          "format"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "CredentialSupportedJwtVcJsonLdAndLdpVc": {
+        "properties": {
+          "types": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "@context": {
+            "items": {
+              "$ref": "#/components/schemas/ICredentialContextType"
+            },
+            "type": "array"
+          },
+          "credentialSubject": {
+            "$ref": "#/components/schemas/IssuerCredentialSubject"
+          },
+          "order": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "format": {
+            "type": "string",
+            "enum": [
+              "ldp_vc",
+              "jwt_vc_json-ld"
+            ]
+          }
+        },
+        "required": [
+          "types",
+          "@context",
+          "format"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "CredentialSupportedSdJwtVc": {
+        "properties": {
+          "format": {
+            "type": "string",
+            "enum": [
+              "vc+sd-jwt"
+            ],
+            "nullable": false
+          },
+          "vct": {
+            "type": "string"
+          },
+          "claims": {
+            "$ref": "#/components/schemas/IssuerCredentialSubject"
+          },
+          "order": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "format",
+          "vct"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "CredentialSupported": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CommonCredentialSupported"
+          },
+          {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CredentialSupportedJwtVcJson"
+              },
+              {
+                "$ref": "#/components/schemas/CredentialSupportedJwtVcJsonLdAndLdpVc"
+              },
+              {
+                "$ref": "#/components/schemas/CredentialSupportedSdJwtVc"
+              }
+            ]
+          }
+        ]
+      },
+      "OpenId4VciCredentialSupportedWithId": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CredentialSupported"
+          },
+          {
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "MetadataDisplay": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/NameAndLocale"
+          },
+          {
+            "$ref": "#/components/schemas/LogoAndColor"
+          },
+          {
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        ]
+      },
+      "OpenId4VciIssuerMetadataDisplay": {
+        "$ref": "#/components/schemas/MetadataDisplay"
+      },
+      "OpenId4VcIssuerRecord": {
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/RecordId"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "publicIssuerId": {
+            "$ref": "#/components/schemas/PublicIssuerId"
+          },
+          "accessTokenPublicKeyFingerprint": {
+            "type": "string"
+          },
+          "credentialsSupported": {
+            "items": {
+              "$ref": "#/components/schemas/OpenId4VciCredentialSupportedWithId"
+            },
+            "type": "array"
+          },
+          "display": {
+            "items": {
+              "$ref": "#/components/schemas/OpenId4VciIssuerMetadataDisplay"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "id",
+          "createdAt",
+          "type",
+          "publicIssuerId",
+          "accessTokenPublicKeyFingerprint",
+          "credentialsSupported"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "OpenId4VcIssuersCreateOptions": {
+        "properties": {
+          "publicIssuerId": {
+            "$ref": "#/components/schemas/PublicIssuerId"
+          },
+          "credentialsSupported": {
+            "items": {
+              "$ref": "#/components/schemas/OpenId4VciCredentialSupportedWithId"
+            },
+            "type": "array"
+          },
+          "display": {
+            "items": {
+              "$ref": "#/components/schemas/OpenId4VciIssuerMetadataDisplay"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "credentialsSupported"
+        ],
+        "type": "object",
+        "additionalProperties": false,
+        "example": {
+          "credentialsSupported": [
+            {
+              "format": "vc+sd-jwt",
+              "id": "ExampleCredentialSdJwtVc",
+              "vct": "https://example.com/vct#ExampleCredential",
+              "cryptographic_binding_methods_supported": [
+                "did:key",
+                "did:jwk"
+              ],
+              "cryptographic_suites_supported": [
+                "ES256",
+                "Ed25519"
+              ],
+              "display": [
+                {
+                  "name": "Example SD JWT Credential",
+                  "description": "This is an example SD-JWT credential",
+                  "background_color": "#ffffff",
+                  "background_image": {
+                    "url": "https://example.com/background.png",
+                    "alt_text": "Example Credential Background"
+                  },
+                  "text_color": "#000000",
+                  "locale": "en-US",
+                  "logo": {
+                    "url": "https://example.com/logo.png",
+                    "alt_text": "Example Credential Logo"
+                  }
+                }
+              ]
+            },
+            {
+              "format": "jwt_vc_json",
+              "id": "ExampleCredentialJwtVc",
+              "types": [
+                "VerifiableCredential",
+                "ExampleCredential"
+              ],
+              "cryptographic_binding_methods_supported": [
+                "did:key",
+                "did:jwk"
+              ],
+              "cryptographic_suites_supported": [
+                "ES256",
+                "Ed25519"
+              ],
+              "display": [
+                {
+                  "name": "Example SD JWT Credential",
+                  "description": "This is an example SD-JWT credential",
+                  "background_color": "#ffffff",
+                  "background_image": {
+                    "url": "https://example.com/background.png",
+                    "alt_text": "Example Credential Background"
+                  },
+                  "text_color": "#000000",
+                  "locale": "en-US",
+                  "logo": {
+                    "url": "https://example.com/logo.png",
+                    "alt_text": "Example Credential Logo"
+                  }
+                }
+              ]
+            }
+          ],
+          "display": [
+            {
+              "background_color": "#ffffff",
+              "description": "This is an example issuer",
+              "name": "Example Issuer",
+              "locale": "en-US",
+              "logo": {
+                "alt_text": "Example Issuer Logo",
+                "url": "https://example.com/logo.png"
+              },
+              "text_color": "#000000"
+            }
+          ]
+        }
+      },
+      "OpenId4VcIssuersUpdateMetadataOptions": {
+        "properties": {
+          "credentialsSupported": {
+            "items": {
+              "$ref": "#/components/schemas/OpenId4VciCredentialSupportedWithId"
+            },
+            "type": "array"
+          },
+          "display": {
+            "items": {
+              "$ref": "#/components/schemas/OpenId4VciIssuerMetadataDisplay"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "credentialsSupported"
+        ],
+        "type": "object",
+        "additionalProperties": false,
+        "example": {
+          "credentialsSupported": [
+            {
+              "format": "vc+sd-jwt",
+              "id": "ExampleCredentialSdJwtVc",
+              "vct": "https://example.com/vct#ExampleCredential",
+              "cryptographic_binding_methods_supported": [
+                "did:key",
+                "did:jwk"
+              ],
+              "cryptographic_suites_supported": [
+                "ES256",
+                "Ed25519"
+              ],
+              "display": [
+                {
+                  "name": "Example SD JWT Credential",
+                  "description": "This is an example SD-JWT credential",
+                  "background_color": "#ffffff",
+                  "background_image": {
+                    "url": "https://example.com/background.png",
+                    "alt_text": "Example Credential Background"
+                  },
+                  "text_color": "#000000",
+                  "locale": "en-US",
+                  "logo": {
+                    "url": "https://example.com/logo.png",
+                    "alt_text": "Example Credential Logo"
+                  }
+                }
+              ]
+            },
+            {
+              "format": "jwt_vc_json",
+              "id": "ExampleCredentialJwtVc",
+              "types": [
+                "VerifiableCredential",
+                "ExampleCredential"
+              ],
+              "cryptographic_binding_methods_supported": [
+                "did:key",
+                "did:jwk"
+              ],
+              "cryptographic_suites_supported": [
+                "ES256",
+                "Ed25519"
+              ],
+              "display": [
+                {
+                  "name": "Example SD JWT Credential",
+                  "description": "This is an example SD-JWT credential",
+                  "background_color": "#ffffff",
+                  "background_image": {
+                    "url": "https://example.com/background.png",
+                    "alt_text": "Example Credential Background"
+                  },
+                  "text_color": "#000000",
+                  "locale": "en-US",
+                  "logo": {
+                    "url": "https://example.com/logo.png",
+                    "alt_text": "Example Credential Logo"
+                  }
+                }
+              ]
+            }
+          ],
+          "display": [
+            {
+              "background_color": "#ffffff",
+              "description": "This is an example issuer",
+              "name": "Example Issuer",
+              "locale": "en-US",
+              "logo": {
+                "alt_text": "Example Issuer Logo",
+                "url": "https://example.com/logo.png"
+              },
+              "text_color": "#000000"
+            }
+          ]
+        }
+      },
+      "OpenId4VcIssuanceSessionState": {
+        "enum": [
+          "OfferCreated",
+          "OfferUriRetrieved",
+          "AccessTokenRequested",
+          "AccessTokenCreated",
+          "CredentialRequestReceived",
+          "CredentialIssued",
+          "Error"
+        ],
+        "type": "string"
+      },
+      "Record_string.unknown_": {
+        "properties": {},
+        "additionalProperties": {},
+        "type": "object",
+        "description": "Construct a type with a set of properties K of type T"
+      },
+      "CommonCredentialOfferFormat": {
+        "properties": {
+          "format": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OID4VCICredentialFormat"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "JsonLdIssuerCredentialDefinition": {
+        "properties": {
+          "@context": {
+            "items": {
+              "$ref": "#/components/schemas/ICredentialContextType"
+            },
+            "type": "array"
+          },
+          "types": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "credentialSubject": {
+            "$ref": "#/components/schemas/IssuerCredentialSubject"
+          }
+        },
+        "required": [
+          "@context",
+          "types"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "CredentialOfferFormatJwtVcJsonLdAndLdpVc": {
+        "properties": {
+          "format": {
+            "type": "string",
+            "enum": [
+              "ldp_vc",
+              "jwt_vc_json-ld"
+            ]
+          },
+          "credential_definition": {
+            "$ref": "#/components/schemas/JsonLdIssuerCredentialDefinition"
+          }
+        },
+        "required": [
+          "format",
+          "credential_definition"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "CredentialOfferFormatJwtVcJson": {
+        "properties": {
+          "format": {
+            "type": "string",
+            "enum": [
+              "jwt_vc_json",
+              "jwt_vc"
+            ]
+          },
+          "types": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "format",
+          "types"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "CredentialOfferFormatSdJwtVc": {
+        "properties": {
+          "format": {
+            "type": "string",
+            "enum": [
+              "vc+sd-jwt"
+            ],
+            "nullable": false
+          },
+          "vct": {
+            "type": "string"
+          },
+          "claims": {
+            "$ref": "#/components/schemas/IssuerCredentialSubject"
+          }
+        },
+        "required": [
+          "format",
+          "vct"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "CredentialOfferFormat": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CommonCredentialOfferFormat"
+          },
+          {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CredentialOfferFormatJwtVcJsonLdAndLdpVc"
+              },
+              {
+                "$ref": "#/components/schemas/CredentialOfferFormatJwtVcJson"
+              },
+              {
+                "$ref": "#/components/schemas/CredentialOfferFormatSdJwtVc"
+              }
+            ]
+          }
+        ]
+      },
+      "GrantAuthorizationCode": {
+        "properties": {
+          "issuer_state": {
+            "type": "string",
+            "description": "OPTIONAL. String value created by the Credential Issuer and opaque to the Wallet that is used to bind the subsequent\nAuthorization Request with the Credential Issuer to a context set up during previous steps."
+          },
+          "authorization_server": {
+            "type": "string",
+            "description": "OPTIONAL string that the Wallet can use to identify the Authorization Server to use with this grant type when authorization_servers parameter in the Credential Issuer metadata has multiple entries. MUST NOT be used otherwise. The value of this parameter MUST match with one of the values in the authorization_servers array obtained from the Credential Issuer metadata"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "GrantUrnIetf": {
+        "properties": {
+          "pre-authorized_code": {
+            "type": "string",
+            "description": "REQUIRED. The code representing the Credential Issuer's authorization for the Wallet to obtain Credentials of a certain type."
+          },
+          "user_pin_required": {
+            "type": "boolean",
+            "description": "OPTIONAL. Boolean value specifying whether the Credential Issuer expects presentation of a user PIN along with the Token Request\nin a Pre-Authorized Code Flow. Default is false."
+          },
+          "interval": {
+            "type": "number",
+            "format": "double",
+            "description": "OPTIONAL. The minimum amount of time in seconds that the Wallet SHOULD wait between polling requests to the token endpoint (in case the Authorization Server responds with error code authorization_pending - see Section 6.3). If no value is provided, Wallets MUST use 5 as the default."
+          },
+          "authorization_server": {
+            "type": "string",
+            "description": "OPTIONAL string that the Wallet can use to identify the Authorization Server to use with this grant type when authorization_servers parameter in the Credential Issuer metadata has multiple entries. MUST NOT be used otherwise. The value of this parameter MUST match with one of the values in the authorization_servers array obtained from the Credential Issuer metadata"
+          }
+        },
+        "required": [
+          "pre-authorized_code",
+          "user_pin_required"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "Grant": {
+        "properties": {
+          "authorization_code": {
+            "$ref": "#/components/schemas/GrantAuthorizationCode"
+          },
+          "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
+            "$ref": "#/components/schemas/GrantUrnIetf"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "CredentialOfferPayloadV1_0_11": {
+        "properties": {
+          "credential_issuer": {
+            "type": "string",
+            "description": "REQUIRED. The URL of the Credential Issuer, the Wallet is requested to obtain one or more Credentials from."
+          },
+          "credentials": {
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/CredentialOfferFormat"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "type": "array",
+            "description": "REQUIRED. A JSON array, where every entry is a JSON object or a JSON string. If the entry is an object,\nthe object contains the data related to a certain credential type the Wallet MAY request.\nEach object MUST contain a format Claim determining the format of the credential to be requested and\nfurther parameters characterising the type of the credential to be requested as defined in Appendix E.\nIf the entry is a string, the string value MUST be one of the id values in one of the objects in the\ncredentials_supported Credential Issuer metadata parameter.\nWhen processing, the Wallet MUST resolve this string value to the respective object."
+          },
+          "grants": {
+            "$ref": "#/components/schemas/Grant",
+            "description": "OPTIONAL. A JSON object indicating to the Wallet the Grant Types the Credential Issuer's AS is prepared\nto process for this credential offer. Every grant is represented by a key and an object.\nThe key value is the Grant Type identifier, the object MAY contain parameters either determining the way\nthe Wallet MUST use the particular grant and/or parameters the Wallet MUST send with the respective request(s).\nIf grants is not present or empty, the Wallet MUST determine the Grant Types the Credential Issuer's AS supports\nusing the respective metadata. When multiple grants are present, it's at the Wallet's discretion which one to use."
+          },
+          "client_id": {
+            "type": "string",
+            "description": "Some implementations might include a client_id in the offer. For instance EBSI in a same-device flow. (Cross-device tucks it in the state JWT)"
+          }
+        },
+        "required": [
+          "credential_issuer",
+          "credentials"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "OpenId4VciCredentialOfferPayload": {
+        "$ref": "#/components/schemas/CredentialOfferPayloadV1_0_11"
+      },
+      "OpenId4VcIssuanceSessionRecord": {
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/RecordId"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "publicIssuerId": {
+            "$ref": "#/components/schemas/PublicIssuerId"
+          },
+          "state": {
+            "$ref": "#/components/schemas/OpenId4VcIssuanceSessionState",
+            "description": "The state of the issuance session."
+          },
+          "cNonce": {
+            "type": "string",
+            "description": "cNonce that should be used in the credential request by the holder."
+          },
+          "cNonceExpiresAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The time at which the cNonce expires."
+          },
+          "preAuthorizedCode": {
+            "type": "string",
+            "description": "Pre authorized code used for the issuance session. Only used when a pre-authorized credential\noffer is created."
+          },
+          "userPin": {
+            "type": "string",
+            "description": "Optional user pin that needs to be provided by the user in the access token request."
+          },
+          "issuanceMetadata": {
+            "$ref": "#/components/schemas/Record_string.unknown_",
+            "description": "User-defined metadata that will be provided to the credential request to credential mapper\nto allow to retrieve the needed credential input data. Can be the credential data itself,\nor some other data that is needed to retrieve the credential data."
+          },
+          "credentialOfferPayload": {
+            "$ref": "#/components/schemas/OpenId4VciCredentialOfferPayload",
+            "description": "The credential offer that was used to create the issuance session."
+          },
+          "credentialOfferUri": {
+            "type": "string",
+            "description": "URI of the credential offer. This is the url that cn can be used to retrieve\nthe credential offer"
+          },
+          "errorMessage": {
+            "type": "string",
+            "description": "Optional error message of the error that occurred during the issuance session. Will be set when state is {@link OpenId4VcIssuanceSessionState.Error}"
+          }
+        },
+        "required": [
+          "id",
+          "createdAt",
+          "type",
+          "publicIssuerId",
+          "state",
+          "credentialOfferPayload",
+          "credentialOfferUri"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "OpenId4VcIssuanceSessionsCreateOfferResponse": {
+        "properties": {
+          "issuanceSession": {
+            "$ref": "#/components/schemas/OpenId4VcIssuanceSessionRecord"
+          },
+          "credentialOffer": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "issuanceSession",
+          "credentialOffer"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "OpenId4VciCredentialFormatProfile.SdJwtVc": {
+        "enum": [
+          "vc+sd-jwt"
+        ],
+        "type": "string"
+      },
+      "Did": {
+        "type": "string"
+      },
+      "DisclosureFrame": {
+        "properties": {},
+        "additionalProperties": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/components/schemas/DisclosureFrame"
+            }
+          ]
+        },
+        "type": "object"
+      },
+      "OpenId4VcIssuanceSessionCreateOfferSdJwtCredentialOptions": {
+        "properties": {
+          "credentialSupportedId": {
+            "type": "string",
+            "description": "The id of the `credential_supported` entry that is present in the issuer\nmetadata. This id is used to identify the credential that is being offered.",
+            "example": "ExampleCredentialSdJwtVc"
+          },
+          "format": {
+            "$ref": "#/components/schemas/OpenId4VciCredentialFormatProfile.SdJwtVc",
+            "description": "The format of the credential that is being offered.\nMUST match the format of the `credential_supported` entry."
+          },
+          "issuer": {
+            "properties": {
+              "didUrl": {
+                "$ref": "#/components/schemas/Did"
+              },
+              "method": {
+                "type": "string",
+                "enum": [
+                  "did"
+                ],
+                "nullable": false
+              }
+            },
+            "required": [
+              "didUrl",
+              "method"
+            ],
+            "type": "object",
+            "description": "The issuer of the credential.\n\nOnly DID based issuance is supported at the moment."
+          },
+          "payload": {
+            "properties": {
+              "vct": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": {},
+            "type": "object",
+            "description": "The payload of the credential that will be issued.\n\nIf `vct` claim is included, it MUST match the `vct` claim from the issuer metadata.\nIf `vct` claim is not included, it will be added automatically.",
+            "example": {
+              "first_name": "John",
+              "last_name": "Doe",
+              "age": {
+                "over_18": true,
+                "over_21": true,
+                "over_65": false
+              }
+            }
+          },
+          "disclosureFrame": {
+            "$ref": "#/components/schemas/DisclosureFrame",
+            "description": "Disclosure frame indicating which fields of the credential can be selectively disclosed.",
+            "example": {
+              "first_name": false,
+              "last_name": false,
+              "age": {
+                "over_18": true,
+                "over_21": true,
+                "over_65": true
+              }
+            }
+          }
+        },
+        "required": [
+          "credentialSupportedId",
+          "format",
+          "issuer",
+          "payload",
+          "disclosureFrame"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "OpenId4VciPreAuthorizedCodeFlowConfig": {
+        "properties": {
+          "preAuthorizedCode": {
+            "type": "string"
+          },
+          "userPinRequired": {
+            "type": "boolean"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "Pick_OpenId4VciCreateCredentialOfferOptions.Exclude_keyofOpenId4VciCreateCredentialOfferOptions.offeredCredentials__": {
+        "properties": {
+          "baseUri": {
+            "type": "string",
+            "description": "baseUri for the credential offer uri. By default `openid-credential-offer://` will be used\nif no value is provided. If a value is provided, make sure it contains the scheme as well as `://`."
+          },
+          "preAuthorizedCodeFlowConfig": {
+            "$ref": "#/components/schemas/OpenId4VciPreAuthorizedCodeFlowConfig"
+          },
+          "issuanceMetadata": {
+            "$ref": "#/components/schemas/Record_string.unknown_",
+            "description": "Metadata about the issuance, that will be stored in the issuance session record and\npassed to the credential request to credential mapper. This can be used to e.g. store an\nuser identifier so user data can be fetched in the credential mapper, or the actual credential\ndata."
+          }
+        },
+        "required": [
+          "preAuthorizedCodeFlowConfig"
+        ],
+        "type": "object",
+        "description": "From T, pick a set of properties whose keys are in the union K"
+      },
+      "OpenId4VcIssuanceSessionsCreateOfferOptions": {
+        "properties": {
+          "baseUri": {
+            "type": "string",
+            "description": "baseUri for the credential offer uri. By default `openid-credential-offer://` will be used\nif no value is provided. If a value is provided, make sure it contains the scheme as well as `://`."
+          },
+          "preAuthorizedCodeFlowConfig": {
+            "$ref": "#/components/schemas/OpenId4VciPreAuthorizedCodeFlowConfig"
+          },
+          "issuanceMetadata": {
+            "$ref": "#/components/schemas/Record_string.unknown_",
+            "description": "Metadata about the issuance, that will be stored in the issuance session record and\npassed to the credential request to credential mapper. This can be used to e.g. store an\nuser identifier so user data can be fetched in the credential mapper, or the actual credential\ndata."
+          },
+          "publicIssuerId": {
+            "$ref": "#/components/schemas/PublicIssuerId"
+          },
+          "credentials": {
+            "items": {
+              "$ref": "#/components/schemas/OpenId4VcIssuanceSessionCreateOfferSdJwtCredentialOptions"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "preAuthorizedCodeFlowConfig",
+          "publicIssuerId",
+          "credentials"
+        ],
+        "type": "object",
+        "additionalProperties": false,
+        "example": {
+          "publicIssuerId": "a868257d-7149-4d4d-a52c-78f3197ee538",
+          "preAuthorizedCodeFlowConfig": {
+            "userPinRequired": false
+          },
+          "credentials": [
+            {
+              "credentialSupportedId": "ExampleCredentialSdJwtVc",
+              "format": "vc+sd-jwt",
+              "issuer": {
+                "method": "did",
+                "didUrl": "did:key:z6MkgViwfstCL1L9i8tgsdAYEu5A62W5mA9DcmSygVVVLFuU#z6MkgViwfstCL1L9i8tgsdAYEu5A62W5mA9DcmSygVVVLFuU"
+              },
+              "payload": {
+                "first_name": "John",
+                "last_name": "Doe",
+                "age": {
+                  "over_18": true,
+                  "over_21": true,
+                  "over_65": false
+                }
+              },
+              "disclosureFrame": {
+                "first_name": false,
+                "last_name": false,
+                "age": {
+                  "over_18": true,
+                  "over_21": true,
+                  "over_65": true
+                }
+              }
+            }
+          ]
+        }
+      },
+      "ThreadId": {
+        "type": "string",
+        "example": "ea4e5e69-fc04-465a-90d2-9f8ff78aa71d"
+      },
+      "ProofState": {
+        "description": "Present Proof protocol states as defined in RFC 0037",
+        "enum": [
+          "proposal-sent",
+          "proposal-received",
+          "request-sent",
+          "request-received",
+          "presentation-sent",
+          "presentation-received",
+          "declined",
+          "abandoned",
+          "done"
+        ],
+        "type": "string"
+      },
+      "ProofRole": {
+        "enum": [
+          "verifier",
+          "prover"
+        ],
+        "type": "string"
+      },
+      "AutoAcceptProof": {
+        "description": "Typing of the state for auto acceptance",
+        "enum": [
+          "always",
+          "contentApproved",
+          "never"
+        ],
+        "type": "string"
+      },
+      "DidCommProofExchangeRecord": {
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/RecordId"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "connectionId": {
+            "$ref": "#/components/schemas/RecordId"
+          },
+          "threadId": {
+            "$ref": "#/components/schemas/ThreadId"
+          },
+          "parentThreadId": {
+            "$ref": "#/components/schemas/ThreadId"
+          },
+          "state": {
+            "$ref": "#/components/schemas/ProofState"
+          },
+          "role": {
+            "$ref": "#/components/schemas/ProofRole"
+          },
+          "autoAcceptProof": {
+            "$ref": "#/components/schemas/AutoAcceptProof"
+          },
+          "errorMessage": {
+            "type": "string"
+          },
+          "protocolVersion": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "createdAt",
+          "type",
+          "threadId",
+          "state",
+          "role",
+          "protocolVersion"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ProofFormatDataMessagePayload_ProofFormats.proposal_": {
+        "properties": {},
+        "type": "object",
+        "description": "Get the format data payload for a specific message from a list of ProofFormat interfaces and a message\n\nFor an indy offer, this resolves to the proof request format as defined here:\nhttps://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0592-indy-attachments#proof-request-format"
+      },
+      "ProofFormatDataMessagePayload_ProofFormats.request_": {
+        "properties": {},
+        "type": "object",
+        "description": "Get the format data payload for a specific message from a list of ProofFormat interfaces and a message\n\nFor an indy offer, this resolves to the proof request format as defined here:\nhttps://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0592-indy-attachments#proof-request-format"
+      },
+      "ProofFormatDataMessagePayload_ProofFormats.presentation_": {
+        "properties": {},
+        "type": "object",
+        "description": "Get the format data payload for a specific message from a list of ProofFormat interfaces and a message\n\nFor an indy offer, this resolves to the proof request format as defined here:\nhttps://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0592-indy-attachments#proof-request-format"
+      },
+      "DidCommProofsGetFormatDataResponse": {
+        "properties": {
+          "presentation": {
+            "$ref": "#/components/schemas/ProofFormatDataMessagePayload_ProofFormats.presentation_"
+          },
+          "request": {
+            "$ref": "#/components/schemas/ProofFormatDataMessagePayload_ProofFormats.request_"
+          },
+          "proposal": {
+            "$ref": "#/components/schemas/ProofFormatDataMessagePayload_ProofFormats.proposal_"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ProofProtocolVersion": {
+        "type": "string",
+        "enum": [
+          "v1",
+          "v2"
+        ]
+      },
+      "AnonCredsPresentationPreviewAttribute": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "credentialDefinitionId": {
+            "type": "string"
+          },
+          "mimeType": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "referent": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AnonCredsPredicateType": {
+        "type": "string",
+        "enum": [
+          ">=",
+          ">",
+          "<=",
+          "<"
+        ]
+      },
+      "AnonCredsPresentationPreviewPredicate": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "credentialDefinitionId": {
+            "type": "string"
+          },
+          "predicate": {
+            "$ref": "#/components/schemas/AnonCredsPredicateType"
+          },
+          "threshold": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "required": [
+          "name",
+          "credentialDefinitionId",
+          "predicate",
+          "threshold"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AnonCredsNonRevokedInterval": {
+        "properties": {
+          "from": {
+            "type": "number",
+            "format": "double"
+          },
+          "to": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AnonCredsProposeProofFormat": {
+        "description": "Interface for creating an anoncreds proof proposal.",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "attributes": {
+            "items": {
+              "$ref": "#/components/schemas/AnonCredsPresentationPreviewAttribute"
+            },
+            "type": "array"
+          },
+          "predicates": {
+            "items": {
+              "$ref": "#/components/schemas/AnonCredsPresentationPreviewPredicate"
+            },
+            "type": "array"
+          },
+          "nonRevokedInterval": {
+            "$ref": "#/components/schemas/AnonCredsNonRevokedInterval"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "Pick_ProposeProofOptions.Exclude_keyofProposeProofOptions.proofFormats-or-protocolVersion__": {
+        "properties": {
+          "connectionId": {
+            "type": "string"
+          },
+          "goalCode": {
+            "type": "string"
+          },
+          "parentThreadId": {
+            "type": "string"
+          },
+          "autoAcceptProof": {
+            "$ref": "#/components/schemas/AutoAcceptProof"
+          },
+          "comment": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "connectionId"
+        ],
+        "type": "object",
+        "description": "From T, pick a set of properties whose keys are in the union K"
+      },
+      "DidCommProofsProposeProofOptions": {
+        "properties": {
+          "connectionId": {
+            "type": "string"
+          },
+          "goalCode": {
+            "type": "string"
+          },
+          "parentThreadId": {
+            "type": "string"
+          },
+          "autoAcceptProof": {
+            "$ref": "#/components/schemas/AutoAcceptProof"
+          },
+          "comment": {
+            "type": "string"
+          },
+          "protocolVersion": {
+            "$ref": "#/components/schemas/ProofProtocolVersion"
+          },
+          "proofFormats": {
+            "properties": {
+              "anoncreds": {
+                "$ref": "#/components/schemas/AnonCredsProposeProofFormat"
+              },
+              "indy": {
+                "$ref": "#/components/schemas/AnonCredsProposeProofFormat"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "required": [
+          "connectionId",
+          "protocolVersion",
+          "proofFormats"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AcceptAnonCredsProposalOptions": {
+        "properties": {},
+        "type": "object",
+        "additionalProperties": false
+      },
+      "Pick_AcceptProofProposalOptions.Exclude_keyofAcceptProofProposalOptions.proofFormats-or-proofRecordId__": {
+        "properties": {
+          "goalCode": {
+            "type": "string"
+          },
+          "autoAcceptProof": {
+            "$ref": "#/components/schemas/AutoAcceptProof"
+          },
+          "comment": {
+            "type": "string"
+          },
+          "willConfirm": {
+            "type": "boolean",
+            "default": true
+          }
+        },
+        "type": "object",
+        "description": "From T, pick a set of properties whose keys are in the union K"
+      },
+      "DidCommProofsAcceptProposalOptions": {
+        "properties": {
+          "goalCode": {
+            "type": "string"
+          },
+          "autoAcceptProof": {
+            "$ref": "#/components/schemas/AutoAcceptProof"
+          },
+          "comment": {
+            "type": "string"
+          },
+          "willConfirm": {
+            "type": "boolean",
+            "default": true
+          },
+          "protocolVersion": {
+            "$ref": "#/components/schemas/ProofProtocolVersion"
+          },
+          "proofFormats": {
+            "properties": {
+              "anoncreds": {
+                "$ref": "#/components/schemas/AcceptAnonCredsProposalOptions"
+              },
+              "indy": {
+                "$ref": "#/components/schemas/AcceptAnonCredsProposalOptions"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "required": [
+          "protocolVersion"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "PlaintextMessage": {
+        "properties": {
+          "@type": {
+            "type": "string"
+          },
+          "@id": {
+            "type": "string"
+          },
+          "~thread": {
+            "properties": {
+              "pthid": {
+                "type": "string"
+              },
+              "thid": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "required": [
+          "@type",
+          "@id"
+        ],
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "DidCommProofsCreateRequestResponse": {
+        "properties": {
+          "message": {
+            "$ref": "#/components/schemas/PlaintextMessage"
+          },
+          "proofExchange": {
+            "$ref": "#/components/schemas/DidCommProofExchangeRecord"
+          }
+        },
+        "required": [
+          "message",
+          "proofExchange"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AnonCredsProofRequestRestrictionOptions": {
+        "properties": {
+          "schema_id": {
+            "type": "string"
+          },
+          "schema_issuer_id": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "schema_version": {
+            "type": "string"
+          },
+          "issuer_id": {
+            "type": "string"
+          },
+          "cred_def_id": {
+            "type": "string"
+          },
+          "rev_reg_id": {
+            "type": "string"
+          },
+          "schema_issuer_did": {
+            "type": "string"
+          },
+          "issuer_did": {
+            "type": "string"
+          },
+          "attributeValues": {
+            "properties": {},
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "attributeMarkers": {
+            "properties": {},
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "type": "object"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AnonCredsRequestedAttributeOptions": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "names": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "restrictions": {
+            "items": {
+              "$ref": "#/components/schemas/AnonCredsProofRequestRestrictionOptions"
+            },
+            "type": "array"
+          },
+          "non_revoked": {
+            "$ref": "#/components/schemas/AnonCredsNonRevokedInterval"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AnonCredsRequestedPredicateOptions": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "p_type": {
+            "$ref": "#/components/schemas/AnonCredsPredicateType"
+          },
+          "p_value": {
+            "type": "number",
+            "format": "double"
+          },
+          "restrictions": {
+            "items": {
+              "$ref": "#/components/schemas/AnonCredsProofRequestRestrictionOptions"
+            },
+            "type": "array"
+          },
+          "non_revoked": {
+            "$ref": "#/components/schemas/AnonCredsNonRevokedInterval"
+          }
+        },
+        "required": [
+          "name",
+          "p_type",
+          "p_value"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AnonCredsRequestProofFormatOptions": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "non_revoked": {
+            "$ref": "#/components/schemas/AnonCredsNonRevokedInterval"
+          },
+          "requested_attributes": {
+            "properties": {},
+            "additionalProperties": {
+              "$ref": "#/components/schemas/AnonCredsRequestedAttributeOptions"
+            },
+            "type": "object"
+          },
+          "requested_predicates": {
+            "properties": {},
+            "additionalProperties": {
+              "$ref": "#/components/schemas/AnonCredsRequestedPredicateOptions"
+            },
+            "type": "object"
+          }
+        },
+        "required": [
+          "name",
+          "version"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "Pick_CreateProofRequestOptions.Exclude_keyofCreateProofRequestOptions.proofFormats-or-protocolVersion__": {
+        "properties": {
+          "goalCode": {
+            "type": "string"
+          },
+          "parentThreadId": {
+            "type": "string"
+          },
+          "autoAcceptProof": {
+            "$ref": "#/components/schemas/AutoAcceptProof"
+          },
+          "comment": {
+            "type": "string"
+          },
+          "willConfirm": {
+            "type": "boolean",
+            "default": true
+          }
+        },
+        "type": "object",
+        "description": "From T, pick a set of properties whose keys are in the union K"
+      },
+      "DidCommProofsCreateRequestOptions": {
+        "properties": {
+          "goalCode": {
+            "type": "string"
+          },
+          "parentThreadId": {
+            "type": "string"
+          },
+          "autoAcceptProof": {
+            "$ref": "#/components/schemas/AutoAcceptProof"
+          },
+          "comment": {
+            "type": "string"
+          },
+          "willConfirm": {
+            "type": "boolean",
+            "default": true
+          },
+          "protocolVersion": {
+            "$ref": "#/components/schemas/ProofProtocolVersion"
+          },
+          "proofFormats": {
+            "properties": {
+              "anoncreds": {
+                "$ref": "#/components/schemas/AnonCredsRequestProofFormatOptions"
+              },
+              "indy": {
+                "$ref": "#/components/schemas/AnonCredsRequestProofFormatOptions"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "required": [
+          "protocolVersion",
+          "proofFormats"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "DidCommProofsSendRequestOptions": {
+        "properties": {
+          "goalCode": {
+            "type": "string"
+          },
+          "parentThreadId": {
+            "type": "string"
+          },
+          "autoAcceptProof": {
+            "$ref": "#/components/schemas/AutoAcceptProof"
+          },
+          "comment": {
+            "type": "string"
+          },
+          "willConfirm": {
+            "type": "boolean",
+            "default": true
+          },
+          "protocolVersion": {
+            "$ref": "#/components/schemas/ProofProtocolVersion"
+          },
+          "proofFormats": {
+            "properties": {
+              "anoncreds": {
+                "$ref": "#/components/schemas/AnonCredsRequestProofFormatOptions"
+              },
+              "indy": {
+                "$ref": "#/components/schemas/AnonCredsRequestProofFormatOptions"
+              }
+            },
+            "type": "object"
+          },
+          "connectionId": {
+            "$ref": "#/components/schemas/RecordId"
+          }
+        },
+        "required": [
+          "protocolVersion",
+          "proofFormats",
+          "connectionId"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "Record_string.string-or-number_": {
+        "properties": {},
+        "additionalProperties": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number",
+              "format": "double"
+            }
+          ]
+        },
+        "type": "object",
+        "description": "Construct a type with a set of properties K of type T"
+      },
+      "AnonCredsClaimRecord": {
+        "$ref": "#/components/schemas/Record_string.string-or-number_"
+      },
+      "AnonCredsCredentialInfo": {
+        "properties": {
+          "credentialId": {
+            "type": "string"
+          },
+          "attributes": {
+            "$ref": "#/components/schemas/AnonCredsClaimRecord"
+          },
+          "schemaId": {
+            "type": "string"
+          },
+          "credentialDefinitionId": {
+            "type": "string"
+          },
+          "revocationRegistryId": {
+            "type": "string",
+            "nullable": true
+          },
+          "credentialRevocationId": {
+            "type": "string",
+            "nullable": true
+          },
+          "methodName": {
+            "type": "string"
+          },
+          "linkSecretId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "credentialId",
+          "attributes",
+          "schemaId",
+          "credentialDefinitionId",
+          "revocationRegistryId",
+          "credentialRevocationId",
+          "methodName",
+          "linkSecretId"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AnonCredsRequestedAttributeMatch": {
+        "properties": {
+          "credentialId": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number",
+            "format": "double"
+          },
+          "revealed": {
+            "type": "boolean"
+          },
+          "credentialInfo": {
+            "$ref": "#/components/schemas/AnonCredsCredentialInfo"
+          },
+          "revoked": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "credentialId",
+          "revealed",
+          "credentialInfo"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "Record_string.AnonCredsRequestedAttributeMatch_": {
+        "properties": {},
+        "additionalProperties": {
+          "$ref": "#/components/schemas/AnonCredsRequestedAttributeMatch"
+        },
+        "type": "object",
+        "description": "Construct a type with a set of properties K of type T"
+      },
+      "AnonCredsRequestedPredicateMatch": {
+        "properties": {
+          "credentialId": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number",
+            "format": "double"
+          },
+          "credentialInfo": {
+            "$ref": "#/components/schemas/AnonCredsCredentialInfo"
+          },
+          "revoked": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "credentialId",
+          "credentialInfo"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "Record_string.AnonCredsRequestedPredicateMatch_": {
+        "properties": {},
+        "additionalProperties": {
+          "$ref": "#/components/schemas/AnonCredsRequestedPredicateMatch"
+        },
+        "type": "object",
+        "description": "Construct a type with a set of properties K of type T"
+      },
+      "Record_string.string_": {
+        "properties": {},
+        "additionalProperties": {
+          "type": "string"
+        },
+        "type": "object",
+        "description": "Construct a type with a set of properties K of type T"
+      },
+      "AnonCredsSelectedCredentials": {
+        "properties": {
+          "attributes": {
+            "$ref": "#/components/schemas/Record_string.AnonCredsRequestedAttributeMatch_"
+          },
+          "predicates": {
+            "$ref": "#/components/schemas/Record_string.AnonCredsRequestedPredicateMatch_"
+          },
+          "selfAttestedAttributes": {
+            "$ref": "#/components/schemas/Record_string.string_"
+          }
+        },
+        "required": [
+          "attributes",
+          "predicates",
+          "selfAttestedAttributes"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "Pick_AcceptProofRequestOptions.Exclude_keyofAcceptProofRequestOptions.proofFormats-or-proofRecordId__": {
+        "properties": {
+          "goalCode": {
+            "type": "string"
+          },
+          "autoAcceptProof": {
+            "$ref": "#/components/schemas/AutoAcceptProof"
+          },
+          "comment": {
+            "type": "string"
+          },
+          "willConfirm": {
+            "type": "boolean",
+            "default": true
+          },
+          "useReturnRoute": {
+            "type": "boolean",
+            "description": "whether to enable return routing on the send presentation message. This value only\nhas an effect for connectionless exchanges."
+          }
+        },
+        "type": "object",
+        "description": "From T, pick a set of properties whose keys are in the union K"
+      },
+      "DidCommProofsAcceptRequestOptions": {
+        "properties": {
+          "goalCode": {
+            "type": "string"
+          },
+          "autoAcceptProof": {
+            "$ref": "#/components/schemas/AutoAcceptProof"
+          },
+          "comment": {
+            "type": "string"
+          },
+          "willConfirm": {
+            "type": "boolean",
+            "default": true
+          },
+          "useReturnRoute": {
+            "type": "boolean",
+            "description": "whether to enable return routing on the send presentation message. This value only\nhas an effect for connectionless exchanges."
+          },
+          "proofFormats": {
+            "properties": {
+              "anoncreds": {
+                "$ref": "#/components/schemas/AnonCredsSelectedCredentials"
+              },
+              "indy": {
+                "$ref": "#/components/schemas/AnonCredsSelectedCredentials"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "OutOfBandRole": {
+        "enum": [
+          "sender",
+          "receiver"
+        ],
+        "type": "string"
+      },
+      "OutOfBandState": {
+        "enum": [
+          "initial",
+          "await-response",
+          "prepare-response",
+          "done"
+        ],
+        "type": "string"
+      },
+      "DidCommOutOfBandRecord": {
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/RecordId"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "outOfBandInvitation": {
+            "$ref": "#/components/schemas/PlaintextMessage",
+            "description": "The out of band invitation"
+          },
+          "role": {
+            "$ref": "#/components/schemas/OutOfBandRole",
+            "description": "Our role in the out of band exchange"
+          },
+          "state": {
+            "$ref": "#/components/schemas/OutOfBandState",
+            "description": "State of the out of band invitation"
+          },
+          "alias": {
+            "type": "string",
+            "description": "Alias for the connection(s) created based on the out of band invitation",
+            "example": "My Connection"
+          },
+          "reusable": {
+            "type": "boolean",
+            "description": "Whether the out of band invitation is reusable",
+            "example": true
+          },
+          "autoAcceptConnection": {
+            "type": "boolean",
+            "description": "Whether to auto accept the out of band invitation.\nIf not defined agent config will be used.",
+            "example": true
+          },
+          "mediatorId": {
+            "$ref": "#/components/schemas/RecordId",
+            "description": "Mediator used for the out of band exchange"
+          },
+          "reuseConnectionId": {
+            "$ref": "#/components/schemas/RecordId",
+            "description": "The id of the connection that was reused for the out of band exchange"
+          }
+        },
+        "required": [
+          "id",
+          "createdAt",
+          "type",
+          "outOfBandInvitation",
+          "role",
+          "state",
+          "reusable"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "DidCommOutOfBandCreateInvitationResponse": {
+        "properties": {
+          "invitation": {
+            "$ref": "#/components/schemas/PlaintextMessage"
+          },
+          "outOfBandRecord": {
+            "$ref": "#/components/schemas/DidCommOutOfBandRecord"
+          },
+          "invitationUrl": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "invitation",
+          "outOfBandRecord",
+          "invitationUrl"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "HandshakeProtocol": {
+        "description": "Enum values should be sorted based on order of preference. Values will be\nincluded in this order when creating out of band invitations.",
+        "enum": [
+          "https://didcomm.org/didexchange/1.x",
+          "https://didcomm.org/connections/1.x"
+        ],
+        "type": "string"
+      },
+      "Pick_CreateOutOfBandInvitationConfig.Exclude_keyofCreateOutOfBandInvitationConfig.routing-or-appendedAttachments-or-messages__": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "goalCode": {
+            "type": "string"
+          },
+          "alias": {
+            "type": "string"
+          },
+          "imageUrl": {
+            "type": "string"
+          },
+          "goal": {
+            "type": "string"
+          },
+          "handshake": {
+            "type": "boolean"
+          },
+          "handshakeProtocols": {
+            "items": {
+              "$ref": "#/components/schemas/HandshakeProtocol"
+            },
+            "type": "array"
+          },
+          "multiUseInvitation": {
+            "type": "boolean"
+          },
+          "autoAcceptConnection": {
+            "type": "boolean"
+          }
+        },
+        "type": "object",
+        "description": "From T, pick a set of properties whose keys are in the union K"
+      },
+      "DidCommOutOfBandCreateInvitationOptions": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "goalCode": {
+            "type": "string"
+          },
+          "alias": {
+            "type": "string"
+          },
+          "imageUrl": {
+            "type": "string"
+          },
+          "goal": {
+            "type": "string"
+          },
+          "handshake": {
+            "type": "boolean"
+          },
+          "handshakeProtocols": {
+            "items": {
+              "$ref": "#/components/schemas/HandshakeProtocol"
+            },
+            "type": "array"
+          },
+          "multiUseInvitation": {
+            "type": "boolean"
+          },
+          "autoAcceptConnection": {
+            "type": "boolean"
+          },
+          "messages": {
+            "items": {
+              "$ref": "#/components/schemas/PlaintextMessage"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "Pick_CreateLegacyInvitationConfig.Exclude_keyofCreateLegacyInvitationConfig.routing__": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "alias": {
+            "type": "string"
+          },
+          "imageUrl": {
+            "type": "string"
+          },
+          "multiUseInvitation": {
+            "type": "boolean"
+          },
+          "autoAcceptConnection": {
+            "type": "boolean"
+          }
+        },
+        "type": "object",
+        "description": "From T, pick a set of properties whose keys are in the union K"
+      },
+      "DidCommOutOfBandCreateLegacyConnectionInvitationOptions": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "alias": {
+            "type": "string"
+          },
+          "imageUrl": {
+            "type": "string"
+          },
+          "multiUseInvitation": {
+            "type": "boolean"
+          },
+          "autoAcceptConnection": {
+            "type": "boolean"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "DidCommOutOfBandCreateLegacyConnectionlessInvitationOptions": {
+        "properties": {
+          "message": {
+            "$ref": "#/components/schemas/PlaintextMessage"
+          },
+          "domain": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message",
+          "domain"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "Pick_ReceiveOutOfBandInvitationConfig.Exclude_keyofReceiveOutOfBandInvitationConfig.routing__": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "alias": {
+            "type": "string"
+          },
+          "imageUrl": {
+            "type": "string"
+          },
+          "autoAcceptConnection": {
+            "type": "boolean"
+          },
+          "autoAcceptInvitation": {
+            "type": "boolean"
+          },
+          "reuseConnection": {
+            "type": "boolean"
+          },
+          "acceptInvitationTimeoutMs": {
+            "type": "number",
+            "format": "double"
+          },
+          "ourDid": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "description": "From T, pick a set of properties whose keys are in the union K"
+      },
+      "DidCommOutOfBandReceiveInvitationOptions": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "alias": {
+            "type": "string"
+          },
+          "imageUrl": {
+            "type": "string"
+          },
+          "autoAcceptConnection": {
+            "type": "boolean"
+          },
+          "autoAcceptInvitation": {
+            "type": "boolean"
+          },
+          "reuseConnection": {
+            "type": "boolean"
+          },
+          "acceptInvitationTimeoutMs": {
+            "type": "number",
+            "format": "double"
+          },
+          "ourDid": {
+            "type": "string"
+          },
+          "invitation": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PlaintextMessage"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "required": [
+          "invitation"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "DidCommOutOfBandAcceptInvitationOptions": {
+        "properties": {
+          "autoAcceptConnection": {
+            "type": "boolean"
+          },
+          "reuseConnection": {
+            "type": "boolean"
+          },
+          "label": {
+            "type": "string"
+          },
+          "alias": {
+            "type": "string"
+          },
+          "imageUrl": {
+            "type": "string"
+          },
+          "timeoutMs": {
+            "type": "number",
+            "format": "double"
+          },
+          "ourDid": {
+            "$ref": "#/components/schemas/Did"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "CredentialState": {
+        "description": "Issue Credential states as defined in RFC 0036 and RFC 0453",
+        "enum": [
+          "proposal-sent",
+          "proposal-received",
+          "offer-sent",
+          "offer-received",
+          "declined",
+          "request-sent",
+          "request-received",
+          "credential-issued",
+          "credential-received",
+          "done",
+          "abandoned"
+        ],
+        "type": "string"
+      },
+      "CredentialRole": {
+        "enum": [
+          "issuer",
+          "holder"
+        ],
+        "type": "string"
+      },
+      "AutoAcceptCredential": {
+        "description": "Typing of the state for auto acceptance",
+        "enum": [
+          "always",
+          "contentApproved",
+          "never"
+        ],
+        "type": "string"
+      },
+      "CredentialRecordBinding": {
+        "properties": {
+          "credentialRecordType": {
+            "type": "string"
+          },
+          "credentialRecordId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "credentialRecordType",
+          "credentialRecordId"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "CredentialPreviewAttributeOptions": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "mimeType": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "value"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "DidCommCredentialExchangeRecord": {
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/RecordId"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "connectionId": {
+            "$ref": "#/components/schemas/RecordId"
+          },
+          "threadId": {
+            "$ref": "#/components/schemas/ThreadId"
+          },
+          "parentThreadId": {
+            "$ref": "#/components/schemas/ThreadId"
+          },
+          "state": {
+            "$ref": "#/components/schemas/CredentialState"
+          },
+          "role": {
+            "$ref": "#/components/schemas/CredentialRole"
+          },
+          "autoAcceptCredential": {
+            "$ref": "#/components/schemas/AutoAcceptCredential"
+          },
+          "revocationNotification": {
+            "properties": {
+              "comment": {
+                "type": "string"
+              },
+              "revocationDate": {
+                "type": "string",
+                "format": "date-time"
+              }
+            },
+            "required": [
+              "revocationDate"
+            ],
+            "type": "object"
+          },
+          "errorMessage": {
+            "type": "string"
+          },
+          "protocolVersion": {
+            "type": "string"
+          },
+          "credentials": {
+            "items": {
+              "$ref": "#/components/schemas/CredentialRecordBinding"
+            },
+            "type": "array"
+          },
+          "credentialAttributes": {
+            "items": {
+              "$ref": "#/components/schemas/CredentialPreviewAttributeOptions"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "id",
+          "createdAt",
+          "type",
+          "threadId",
+          "state",
+          "role",
+          "protocolVersion",
+          "credentials"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "Pick_AnonCredsCredentialProposalFormat.Exclude_keyofAnonCredsCredentialProposalFormat.schema_issuer_id-or-issuer_id__": {
+        "properties": {
+          "schema_name": {
+            "type": "string"
+          },
+          "schema_version": {
+            "type": "string"
+          },
+          "schema_id": {
+            "type": "string"
+          },
+          "cred_def_id": {
+            "type": "string"
+          },
+          "schema_issuer_did": {
+            "type": "string"
+          },
+          "issuer_did": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "description": "From T, pick a set of properties whose keys are in the union K"
+      },
+      "Omit_AnonCredsCredentialProposalFormat.schema_issuer_id-or-issuer_id_": {
+        "$ref": "#/components/schemas/Pick_AnonCredsCredentialProposalFormat.Exclude_keyofAnonCredsCredentialProposalFormat.schema_issuer_id-or-issuer_id__",
+        "description": "Construct a type with the properties of T except for those in type K."
+      },
+      "LegacyIndyCredentialProposalFormat": {
+        "$ref": "#/components/schemas/Omit_AnonCredsCredentialProposalFormat.schema_issuer_id-or-issuer_id_"
+      },
+      "AnonCredsCredentialProposalFormat": {
+        "properties": {
+          "schema_issuer_id": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "schema_version": {
+            "type": "string"
+          },
+          "schema_id": {
+            "type": "string"
+          },
+          "cred_def_id": {
+            "type": "string"
+          },
+          "issuer_id": {
+            "type": "string"
+          },
+          "schema_issuer_did": {
+            "type": "string"
+          },
+          "issuer_did": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "CredentialFormatDataMessagePayload_CredentialFormats.proposal_": {
+        "properties": {
+          "indy": {
+            "$ref": "#/components/schemas/LegacyIndyCredentialProposalFormat"
+          },
+          "anoncreds": {
+            "$ref": "#/components/schemas/AnonCredsCredentialProposalFormat"
+          }
+        },
+        "type": "object",
+        "description": "Get the format data payload for a specific message from a list of CredentialFormat interfaces and a message\n\nFor an indy offer, this resolves to the cred abstract format as defined here:\nhttps://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0592-indy-attachments#cred-abstract-format"
+      },
+      "LegacyIndyCredentialRequest": {
+        "properties": {
+          "prover_did": {
+            "type": "string"
+          },
+          "entropy": {
+            "type": "string"
+          },
+          "cred_def_id": {
+            "type": "string"
+          },
+          "blinded_ms": {
+            "$ref": "#/components/schemas/Record_string.unknown_"
+          },
+          "blinded_ms_correctness_proof": {
+            "$ref": "#/components/schemas/Record_string.unknown_"
+          },
+          "nonce": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cred_def_id",
+          "blinded_ms",
+          "blinded_ms_correctness_proof",
+          "nonce",
+          "prover_did"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AnonCredsCredentialRequest": {
+        "properties": {
+          "prover_did": {
+            "type": "string"
+          },
+          "entropy": {
+            "type": "string"
+          },
+          "cred_def_id": {
+            "type": "string"
+          },
+          "blinded_ms": {
+            "$ref": "#/components/schemas/Record_string.unknown_"
+          },
+          "blinded_ms_correctness_proof": {
+            "$ref": "#/components/schemas/Record_string.unknown_"
+          },
+          "nonce": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cred_def_id",
+          "blinded_ms",
+          "blinded_ms_correctness_proof",
+          "nonce"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "CredentialFormatDataMessagePayload_CredentialFormats.request_": {
+        "properties": {
+          "indy": {
+            "$ref": "#/components/schemas/LegacyIndyCredentialRequest"
+          },
+          "anoncreds": {
+            "$ref": "#/components/schemas/AnonCredsCredentialRequest"
+          }
+        },
+        "type": "object",
+        "description": "Get the format data payload for a specific message from a list of CredentialFormat interfaces and a message\n\nFor an indy offer, this resolves to the cred abstract format as defined here:\nhttps://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0592-indy-attachments#cred-abstract-format"
+      },
+      "AnonCredsCredentialOffer": {
+        "properties": {
+          "schema_id": {
+            "type": "string"
+          },
+          "cred_def_id": {
+            "type": "string"
+          },
+          "nonce": {
+            "type": "string"
+          },
+          "key_correctness_proof": {
+            "$ref": "#/components/schemas/Record_string.unknown_"
+          }
+        },
+        "required": [
+          "schema_id",
+          "cred_def_id",
+          "nonce",
+          "key_correctness_proof"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "CredentialFormatDataMessagePayload_CredentialFormats.offer_": {
+        "properties": {
+          "indy": {
+            "$ref": "#/components/schemas/AnonCredsCredentialOffer"
+          },
+          "anoncreds": {
+            "$ref": "#/components/schemas/AnonCredsCredentialOffer"
+          }
+        },
+        "type": "object",
+        "description": "Get the format data payload for a specific message from a list of CredentialFormat interfaces and a message\n\nFor an indy offer, this resolves to the cred abstract format as defined here:\nhttps://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0592-indy-attachments#cred-abstract-format"
+      },
+      "AnonCredsCredentialValue": {
+        "properties": {
+          "raw": {
+            "type": "string"
+          },
+          "encoded": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "raw",
+          "encoded"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "Record_string.AnonCredsCredentialValue_": {
+        "properties": {},
+        "additionalProperties": {
+          "$ref": "#/components/schemas/AnonCredsCredentialValue"
+        },
+        "type": "object",
+        "description": "Construct a type with a set of properties K of type T"
+      },
+      "AnonCredsCredential": {
+        "properties": {
+          "schema_id": {
+            "type": "string"
+          },
+          "cred_def_id": {
+            "type": "string"
+          },
+          "rev_reg_id": {
+            "type": "string"
+          },
+          "values": {
+            "$ref": "#/components/schemas/Record_string.AnonCredsCredentialValue_"
+          },
+          "signature": {},
+          "signature_correctness_proof": {}
+        },
+        "required": [
+          "schema_id",
+          "cred_def_id",
+          "values",
+          "signature",
+          "signature_correctness_proof"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "CredentialFormatDataMessagePayload_CredentialFormats.credential_": {
+        "properties": {
+          "indy": {
+            "$ref": "#/components/schemas/AnonCredsCredential"
+          },
+          "anoncreds": {
+            "$ref": "#/components/schemas/AnonCredsCredential"
+          }
+        },
+        "type": "object",
+        "description": "Get the format data payload for a specific message from a list of CredentialFormat interfaces and a message\n\nFor an indy offer, this resolves to the cred abstract format as defined here:\nhttps://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0592-indy-attachments#cred-abstract-format"
+      },
+      "Pick_GetCredentialFormatDataReturn_CredentialFormats_.Exclude_keyofGetCredentialFormatDataReturn_CredentialFormats_.offerAttributes__": {
+        "properties": {
+          "proposal": {
+            "$ref": "#/components/schemas/CredentialFormatDataMessagePayload_CredentialFormats.proposal_"
+          },
+          "request": {
+            "$ref": "#/components/schemas/CredentialFormatDataMessagePayload_CredentialFormats.request_"
+          },
+          "offer": {
+            "$ref": "#/components/schemas/CredentialFormatDataMessagePayload_CredentialFormats.offer_"
+          },
+          "credential": {
+            "$ref": "#/components/schemas/CredentialFormatDataMessagePayload_CredentialFormats.credential_"
+          },
+          "proposalAttributes": {
+            "items": {
+              "$ref": "#/components/schemas/CredentialPreviewAttributeOptions"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object",
+        "description": "From T, pick a set of properties whose keys are in the union K"
+      },
+      "DidCommCredentialsGetFormatDataResponse": {
+        "properties": {
+          "proposal": {
+            "$ref": "#/components/schemas/CredentialFormatDataMessagePayload_CredentialFormats.proposal_"
+          },
+          "request": {
+            "$ref": "#/components/schemas/CredentialFormatDataMessagePayload_CredentialFormats.request_"
+          },
+          "offer": {
+            "$ref": "#/components/schemas/CredentialFormatDataMessagePayload_CredentialFormats.offer_"
+          },
+          "credential": {
+            "$ref": "#/components/schemas/CredentialFormatDataMessagePayload_CredentialFormats.credential_"
+          },
+          "proposalAttributes": {
+            "items": {
+              "$ref": "#/components/schemas/CredentialPreviewAttributeOptions"
+            },
+            "type": "array"
+          },
+          "offerAttributes": {
+            "items": {
+              "properties": {
+                "value": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "mime-type": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "value",
+                "name"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "CredentialProtocolVersion": {
+        "type": "string",
+        "enum": [
+          "v1",
+          "v2"
+        ]
+      },
+      "Pick_JwsGeneralFormat.Exclude_keyofJwsGeneralFormat.payload__": {
+        "properties": {
+          "header": {
+            "$ref": "#/components/schemas/Record_string.unknown_",
+            "description": "unprotected header"
+          },
+          "signature": {
+            "type": "string",
+            "description": "Base64url encoded signature"
+          },
+          "protected": {
+            "type": "string",
+            "description": "Base64url encoded protected header"
+          }
+        },
+        "required": [
+          "header",
+          "signature",
+          "protected"
+        ],
+        "type": "object",
+        "description": "From T, pick a set of properties whose keys are in the union K"
+      },
+      "Omit_JwsGeneralFormat.payload_": {
+        "$ref": "#/components/schemas/Pick_JwsGeneralFormat.Exclude_keyofJwsGeneralFormat.payload__",
+        "description": "Construct a type with the properties of T except for those in type K."
+      },
+      "JwsDetachedFormat": {
+        "$ref": "#/components/schemas/Omit_JwsGeneralFormat.payload_"
+      },
+      "JwsFlattenedDetachedFormat": {
+        "properties": {
+          "signatures": {
+            "items": {
+              "$ref": "#/components/schemas/JwsDetachedFormat"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "signatures"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AttachmentData": {
+        "description": "A JSON object that gives access to the actual content of the attachment",
+        "properties": {
+          "base64": {
+            "type": "string",
+            "description": "Base64-encoded data, when representing arbitrary content inline instead of via links. Optional."
+          },
+          "json": {
+            "$ref": "#/components/schemas/JsonValue",
+            "description": "Directly embedded JSON data, when representing content inline instead of via links, and when the content is natively conveyable as JSON. Optional."
+          },
+          "links": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "A list of zero or more locations at which the content may be fetched. Optional."
+          },
+          "jws": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/JwsDetachedFormat"
+              },
+              {
+                "$ref": "#/components/schemas/JwsFlattenedDetachedFormat"
+              }
+            ],
+            "description": "A JSON Web Signature over the content of the attachment. Optional."
+          },
+          "sha256": {
+            "type": "string",
+            "description": "The hash of the content. Optional."
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "Attachment": {
+        "description": "Represents DIDComm attachment\nhttps://github.com/hyperledger/aries-rfcs/blob/master/concepts/0017-attachments/README.md",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "description": "An optional human-readable description of the content."
+          },
+          "filename": {
+            "type": "string",
+            "description": "A hint about the name that might be used if this attachment is persisted as a file. It is not required, and need not be unique. If this field is present and mime-type is not, the extension on the filename may be used to infer a MIME type."
+          },
+          "mimeType": {
+            "type": "string",
+            "description": "Describes the MIME type of the attached content. Optional but recommended."
+          },
+          "lastmodTime": {
+            "type": "string",
+            "format": "date-time",
+            "description": "A hint about when the content in this attachment was last modified."
+          },
+          "byteCount": {
+            "type": "number",
+            "format": "double",
+            "description": "Optional, and mostly relevant when content is included by reference instead of by value. Lets the receiver guess how expensive it will be, in time, bandwidth, and storage, to fully fetch the attachment."
+          },
+          "data": {
+            "$ref": "#/components/schemas/AttachmentData"
+          }
+        },
+        "required": [
+          "id",
+          "data"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "LinkedAttachment": {
+        "properties": {
+          "attributeName": {
+            "type": "string",
+            "description": "The name that will be used to generate the linked credential"
+          },
+          "attachment": {
+            "$ref": "#/components/schemas/Attachment",
+            "description": "The attachment that needs to be linked to the credential"
+          }
+        },
+        "required": [
+          "attributeName",
+          "attachment"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AnonCredsProposeCredentialFormat": {
+        "description": "This defines the module payload for calling CredentialsApi.createProposal\nor CredentialsApi.negotiateOffer",
+        "properties": {
+          "schemaIssuerId": {
+            "type": "string"
+          },
+          "schemaId": {
+            "type": "string"
+          },
+          "schemaName": {
+            "type": "string"
+          },
+          "schemaVersion": {
+            "type": "string"
+          },
+          "credentialDefinitionId": {
+            "type": "string"
+          },
+          "issuerId": {
+            "type": "string"
+          },
+          "attributes": {
+            "items": {
+              "$ref": "#/components/schemas/CredentialPreviewAttributeOptions"
+            },
+            "type": "array"
+          },
+          "linkedAttachments": {
+            "items": {
+              "$ref": "#/components/schemas/LinkedAttachment"
+            },
+            "type": "array"
+          },
+          "schemaIssuerDid": {
+            "type": "string"
+          },
+          "issuerDid": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "Pick_AnonCredsProposeCredentialFormat.Exclude_keyofAnonCredsProposeCredentialFormat.schemaIssuerId-or-issuerId__": {
+        "properties": {
+          "schemaId": {
+            "type": "string"
+          },
+          "schemaName": {
+            "type": "string"
+          },
+          "schemaVersion": {
+            "type": "string"
+          },
+          "credentialDefinitionId": {
+            "type": "string"
+          },
+          "attributes": {
+            "items": {
+              "$ref": "#/components/schemas/CredentialPreviewAttributeOptions"
+            },
+            "type": "array"
+          },
+          "linkedAttachments": {
+            "items": {
+              "$ref": "#/components/schemas/LinkedAttachment"
+            },
+            "type": "array"
+          },
+          "schemaIssuerDid": {
+            "type": "string"
+          },
+          "issuerDid": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "description": "From T, pick a set of properties whose keys are in the union K"
+      },
+      "Omit_AnonCredsProposeCredentialFormat.schemaIssuerId-or-issuerId_": {
+        "$ref": "#/components/schemas/Pick_AnonCredsProposeCredentialFormat.Exclude_keyofAnonCredsProposeCredentialFormat.schemaIssuerId-or-issuerId__",
+        "description": "Construct a type with the properties of T except for those in type K."
+      },
+      "LegacyIndyProposeCredentialFormat": {
+        "$ref": "#/components/schemas/Omit_AnonCredsProposeCredentialFormat.schemaIssuerId-or-issuerId_",
+        "description": "This defines the module payload for calling CredentialsApi.createProposal\nor CredentialsApi.negotiateOffer\n\nNOTE: This doesn't include the `issuerId` and `schemaIssuerId` properties that are present in the newer format."
+      },
+      "ProposeCredentialOptions": {
+        "properties": {
+          "protocolVersion": {
+            "$ref": "#/components/schemas/CredentialProtocolVersion"
+          },
+          "credentialFormats": {
+            "properties": {
+              "indy": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/AnonCredsProposeCredentialFormat"
+                  },
+                  {
+                    "$ref": "#/components/schemas/LegacyIndyProposeCredentialFormat"
+                  }
+                ]
+              },
+              "anoncreds": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/AnonCredsProposeCredentialFormat"
+                  },
+                  {
+                    "$ref": "#/components/schemas/LegacyIndyProposeCredentialFormat"
+                  }
+                ]
+              }
+            },
+            "type": "object"
+          },
+          "autoAcceptCredential": {
+            "$ref": "#/components/schemas/AutoAcceptCredential"
+          },
+          "comment": {
+            "type": "string"
+          },
+          "connectionId": {
+            "$ref": "#/components/schemas/RecordId"
+          }
+        },
+        "required": [
+          "protocolVersion",
+          "credentialFormats",
+          "connectionId"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AnonCredsAcceptProposalFormat": {
+        "description": "This defines the module payload for calling CredentialsApi.acceptProposal",
+        "properties": {
+          "credentialDefinitionId": {
+            "type": "string"
+          },
+          "revocationRegistryDefinitionId": {
+            "type": "string"
+          },
+          "revocationRegistryIndex": {
+            "type": "number",
+            "format": "double"
+          },
+          "attributes": {
+            "items": {
+              "$ref": "#/components/schemas/CredentialPreviewAttributeOptions"
+            },
+            "type": "array"
+          },
+          "linkedAttachments": {
+            "items": {
+              "$ref": "#/components/schemas/LinkedAttachment"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AcceptCredentialProposalOptions": {
+        "properties": {
+          "credentialFormats": {
+            "properties": {
+              "indy": {
+                "$ref": "#/components/schemas/AnonCredsAcceptProposalFormat"
+              },
+              "anoncreds": {
+                "$ref": "#/components/schemas/AnonCredsAcceptProposalFormat"
+              }
+            },
+            "type": "object"
+          },
+          "autoAcceptCredential": {
+            "$ref": "#/components/schemas/AutoAcceptCredential"
+          },
+          "comment": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "DidCommCredentialsCreateOfferResponse": {
+        "properties": {
+          "message": {
+            "$ref": "#/components/schemas/PlaintextMessage"
+          },
+          "credentialExchange": {
+            "$ref": "#/components/schemas/DidCommCredentialExchangeRecord"
+          }
+        },
+        "required": [
+          "message",
+          "credentialExchange"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AnonCredsOfferCredentialFormat": {
+        "description": "This defines the module payload for calling CredentialsApi.offerCredential\nor CredentialsApi.negotiateProposal",
+        "properties": {
+          "credentialDefinitionId": {
+            "type": "string"
+          },
+          "revocationRegistryDefinitionId": {
+            "type": "string"
+          },
+          "revocationRegistryIndex": {
+            "type": "number",
+            "format": "double"
+          },
+          "attributes": {
+            "items": {
+              "$ref": "#/components/schemas/CredentialPreviewAttributeOptions"
+            },
+            "type": "array"
+          },
+          "linkedAttachments": {
+            "items": {
+              "$ref": "#/components/schemas/LinkedAttachment"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "credentialDefinitionId",
+          "attributes"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "CredentialFormatPayload_CredentialFormats.createOffer_": {
+        "properties": {
+          "indy": {
+            "$ref": "#/components/schemas/AnonCredsOfferCredentialFormat"
+          },
+          "anoncreds": {
+            "$ref": "#/components/schemas/AnonCredsOfferCredentialFormat"
+          }
+        },
+        "type": "object",
+        "description": "Get the payload for a specific method from a list of CredentialFormat interfaces and a method"
+      },
+      "CreateOfferOptions": {
+        "properties": {
+          "protocolVersion": {
+            "$ref": "#/components/schemas/CredentialProtocolVersion"
+          },
+          "credentialFormats": {
+            "$ref": "#/components/schemas/CredentialFormatPayload_CredentialFormats.createOffer_"
+          },
+          "autoAcceptCredential": {
+            "$ref": "#/components/schemas/AutoAcceptCredential"
+          },
+          "comment": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "protocolVersion",
+          "credentialFormats"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "OfferCredentialOptions": {
+        "properties": {
+          "protocolVersion": {
+            "$ref": "#/components/schemas/CredentialProtocolVersion"
+          },
+          "credentialFormats": {
+            "$ref": "#/components/schemas/CredentialFormatPayload_CredentialFormats.createOffer_"
+          },
+          "autoAcceptCredential": {
+            "$ref": "#/components/schemas/AutoAcceptCredential"
+          },
+          "comment": {
+            "type": "string"
+          },
+          "connectionId": {
+            "$ref": "#/components/schemas/RecordId"
+          }
+        },
+        "required": [
+          "protocolVersion",
+          "credentialFormats",
+          "connectionId"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AnonCredsAcceptOfferFormat": {
+        "description": "This defines the module payload for calling CredentialsApi.acceptOffer. No options are available for this\nmethod, so it's an empty object",
+        "properties": {
+          "linkSecretId": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "CredentialFormatPayload_CredentialFormats.acceptOffer_": {
+        "properties": {
+          "indy": {
+            "$ref": "#/components/schemas/AnonCredsAcceptOfferFormat"
+          },
+          "anoncreds": {
+            "$ref": "#/components/schemas/AnonCredsAcceptOfferFormat"
+          }
+        },
+        "type": "object",
+        "description": "Get the payload for a specific method from a list of CredentialFormat interfaces and a method"
+      },
+      "AcceptCredentialOfferOptions": {
+        "properties": {
+          "credentialFormats": {
+            "$ref": "#/components/schemas/CredentialFormatPayload_CredentialFormats.acceptOffer_"
+          },
+          "autoAcceptCredential": {
+            "$ref": "#/components/schemas/AutoAcceptCredential"
+          },
+          "comment": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "Record_string.never_": {
+        "properties": {},
+        "type": "object",
+        "description": "Construct a type with a set of properties K of type T"
+      },
+      "AnonCredsAcceptRequestFormat": {
+        "$ref": "#/components/schemas/Record_string.never_",
+        "description": "This defines the module payload for calling CredentialsApi.acceptRequest. No options are available for this\nmethod, so it's an empty object"
+      },
+      "CredentialFormatPayload_CredentialFormats.acceptRequest_": {
+        "properties": {
+          "indy": {
+            "$ref": "#/components/schemas/AnonCredsAcceptRequestFormat"
+          },
+          "anoncreds": {
+            "$ref": "#/components/schemas/AnonCredsAcceptRequestFormat"
+          }
+        },
+        "type": "object",
+        "description": "Get the payload for a specific method from a list of CredentialFormat interfaces and a method"
+      },
+      "AcceptCredentialRequestOptions": {
+        "properties": {
+          "credentialFormats": {
+            "$ref": "#/components/schemas/CredentialFormatPayload_CredentialFormats.acceptRequest_"
+          },
+          "autoAcceptCredential": {
+            "$ref": "#/components/schemas/AutoAcceptCredential"
+          },
+          "comment": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "DidExchangeState": {
+        "description": "Connection states as defined in RFC 0023.",
+        "enum": [
+          "start",
+          "invitation-sent",
+          "invitation-received",
+          "request-sent",
+          "request-received",
+          "response-sent",
+          "response-received",
+          "abandoned",
+          "completed"
+        ],
+        "type": "string"
+      },
+      "DidExchangeRole": {
+        "enum": [
+          "requester",
+          "responder"
+        ],
+        "type": "string"
+      },
+      "ConnectionType": {
+        "enum": [
+          "mediator"
+        ],
+        "type": "string"
+      },
+      "DidCommConnectionRecord": {
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/RecordId"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "did": {
+            "$ref": "#/components/schemas/Did"
+          },
+          "theirDid": {
+            "$ref": "#/components/schemas/Did"
+          },
+          "theirLabel": {
+            "type": "string"
+          },
+          "state": {
+            "$ref": "#/components/schemas/DidExchangeState"
+          },
+          "role": {
+            "$ref": "#/components/schemas/DidExchangeRole"
+          },
+          "alias": {
+            "type": "string"
+          },
+          "autoAcceptConnection": {
+            "type": "boolean"
+          },
+          "threadId": {
+            "$ref": "#/components/schemas/ThreadId"
+          },
+          "imageUrl": {
+            "type": "string"
+          },
+          "mediatorId": {
+            "type": "string"
+          },
+          "errorMessage": {
+            "type": "string"
+          },
+          "protocol": {
+            "$ref": "#/components/schemas/HandshakeProtocol"
+          },
+          "outOfBandId": {
+            "type": "string"
+          },
+          "invitationDid": {
+            "$ref": "#/components/schemas/Did"
+          },
+          "connectionTypes": {
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/ConnectionType"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "previousDids": {
+            "items": {
+              "$ref": "#/components/schemas/Did"
+            },
+            "type": "array"
+          },
+          "previousTheirDids": {
+            "items": {
+              "$ref": "#/components/schemas/Did"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "id",
+          "createdAt",
+          "type",
+          "state",
+          "role"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "BasicMessageRole": {
+        "enum": [
+          "sender",
+          "receiver"
+        ],
+        "type": "string"
+      },
+      "DidCommBasicMessageRecord": {
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/RecordId"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "connectionId": {
+            "$ref": "#/components/schemas/RecordId"
+          },
+          "role": {
+            "$ref": "#/components/schemas/BasicMessageRole"
+          },
+          "content": {
+            "type": "string"
+          },
+          "sentTime": {
+            "type": "string"
+          },
+          "threadId": {
+            "$ref": "#/components/schemas/ThreadId"
+          },
+          "parentThreadId": {
+            "$ref": "#/components/schemas/ThreadId"
+          }
+        },
+        "required": [
+          "id",
+          "createdAt",
+          "type",
+          "connectionId",
+          "role",
+          "content",
+          "sentTime"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "DidCommBasicMessagesSendOptions": {
+        "properties": {
+          "connectionId": {
+            "$ref": "#/components/schemas/RecordId"
+          },
+          "content": {
+            "type": "string"
+          },
+          "parentThreadId": {
+            "$ref": "#/components/schemas/ThreadId"
+          }
+        },
+        "required": [
+          "connectionId",
+          "content"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "DidResolutionMetadata": {
+        "properties": {
+          "contentType": {
+            "type": "string"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "invalidDid",
+                  "notFound",
+                  "representationNotSupported",
+                  "unsupportedDidMethod"
+                ]
+              }
+            ]
+          },
+          "message": {
+            "type": "string"
+          },
+          "servedFromCache": {
+            "type": "boolean"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "JsonWebKey": {
+        "description": "Encapsulates a JSON web key type that includes only the public properties that\r\ncan be used in DID documents.\r\n\r\nThe private properties are intentionally omitted to discourage the use\r\n(and accidental disclosure) of private keys in DID documents.",
+        "properties": {
+          "alg": {
+            "type": "string"
+          },
+          "crv": {
+            "type": "string"
+          },
+          "e": {
+            "type": "string"
+          },
+          "ext": {
+            "type": "boolean"
+          },
+          "key_ops": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "kid": {
+            "type": "string"
+          },
+          "kty": {
+            "type": "string"
+          },
+          "n": {
+            "type": "string"
+          },
+          "use": {
+            "type": "string"
+          },
+          "x": {
+            "type": "string"
+          },
+          "y": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kty"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "VerificationMethod": {
+        "description": "Represents the properties of a Verification Method listed in a DID document.\r\n\r\nThis data type includes public key representations that are no longer present in the spec but are still used by\r\nseveral DID methods / resolvers and kept for backward compatibility.",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "controller": {
+            "type": "string"
+          },
+          "publicKeyBase58": {
+            "type": "string"
+          },
+          "publicKeyBase64": {
+            "type": "string"
+          },
+          "publicKeyJwk": {
+            "$ref": "#/components/schemas/JsonWebKey"
+          },
+          "publicKeyHex": {
+            "type": "string"
+          },
+          "publicKeyMultibase": {
+            "type": "string"
+          },
+          "blockchainAccountId": {
+            "type": "string"
+          },
+          "ethereumAddress": {
+            "type": "string"
+          },
+          "conditionOr": {
+            "items": {
+              "$ref": "#/components/schemas/VerificationMethod"
+            },
+            "type": "array"
+          },
+          "conditionAnd": {
+            "items": {
+              "$ref": "#/components/schemas/VerificationMethod"
+            },
+            "type": "array"
+          },
+          "threshold": {
+            "type": "number",
+            "format": "double"
+          },
+          "conditionThreshold": {
+            "items": {
+              "$ref": "#/components/schemas/VerificationMethod"
+            },
+            "type": "array"
+          },
+          "conditionWeightedThreshold": {
+            "items": {
+              "$ref": "#/components/schemas/ConditionWeightedThreshold"
+            },
+            "type": "array"
+          },
+          "conditionDelegated": {
+            "type": "string"
+          },
+          "relationshipParent": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "relationshipChild": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "relationshipSibling": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "controller"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ConditionWeightedThreshold": {
+        "properties": {
+          "condition": {
+            "$ref": "#/components/schemas/VerificationMethod"
+          },
+          "weight": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "required": [
+          "condition",
+          "weight"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ServiceEndpoint": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "$ref": "#/components/schemas/Record_string.any_"
+          }
+        ],
+        "description": "Represents an endpoint of a Service entry in a DID document."
+      },
+      "Service": {
+        "description": "Represents a Service entry in a {@link https://www.w3.org/TR/did-core/#did-document-properties DID document}.",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "serviceEndpoint": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ServiceEndpoint"
+              },
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ServiceEndpoint"
+                },
+                "type": "array"
+              }
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "serviceEndpoint"
+        ],
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "DIDDocument": {
+        "allOf": [
+          {
+            "properties": {
+              "publicKey": {
+                "items": {
+                  "$ref": "#/components/schemas/VerificationMethod"
+                },
+                "type": "array",
+                "deprecated": true
+              },
+              "service": {
+                "items": {
+                  "$ref": "#/components/schemas/Service"
+                },
+                "type": "array"
+              },
+              "verificationMethod": {
+                "items": {
+                  "$ref": "#/components/schemas/VerificationMethod"
+                },
+                "type": "array"
+              },
+              "controller": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                ]
+              },
+              "alsoKnownAs": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "id": {
+                "type": "string"
+              },
+              "@context": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  {
+                    "type": "string",
+                    "enum": [
+                      "https://www.w3.org/ns/did/v1"
+                    ]
+                  }
+                ]
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "authentication": {
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "$ref": "#/components/schemas/VerificationMethod"
+                    }
+                  ]
+                },
+                "type": "array"
+              },
+              "assertionMethod": {
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "$ref": "#/components/schemas/VerificationMethod"
+                    }
+                  ]
+                },
+                "type": "array"
+              },
+              "keyAgreement": {
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "$ref": "#/components/schemas/VerificationMethod"
+                    }
+                  ]
+                },
+                "type": "array"
+              },
+              "capabilityInvocation": {
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "$ref": "#/components/schemas/VerificationMethod"
+                    }
+                  ]
+                },
+                "type": "array"
+              },
+              "capabilityDelegation": {
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "$ref": "#/components/schemas/VerificationMethod"
+                    }
+                  ]
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "description": "Represents a DID document."
+      },
+      "DidDocumentJson": {
+        "$ref": "#/components/schemas/DIDDocument",
+        "example": {
+          "@context": [
+            "https://w3id.org/did/v1",
+            "https://w3id.org/security/suites/ed25519-2018/v1",
+            "https://w3id.org/security/suites/x25519-2019/v1"
+          ],
+          "id": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+          "verificationMethod": [
+            {
+              "id": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK#z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+              "type": "Ed25519VerificationKey2018",
+              "controller": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+              "publicKeyBase58": "48GdbJyVULjHDaBNS6ct9oAGtckZUS5v8asrPzvZ7R1w"
+            }
+          ],
+          "authentication": [
+            "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK#z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
+          ],
+          "assertionMethod": [
+            "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK#z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
+          ],
+          "keyAgreement": [
+            {
+              "id": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK#z6LSj72tK8brWgZja8NLRwPigth2T9QRiG1uH9oKZuKjdh9p",
+              "type": "X25519KeyAgreementKey2019",
+              "controller": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+              "publicKeyBase58": "8RrinpnzRDqzUjzZuHsmNJUYbzsK1eqkQB5e5SgCvKP4"
+            }
+          ],
+          "capabilityInvocation": [
+            "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK#z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
+          ],
+          "capabilityDelegation": [
+            "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK#z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
+          ]
+        }
+      },
+      "DIDDocumentMetadata": {
+        "description": "Represents metadata about the DID document resulting from a {@link Resolvable.resolve} operation.",
+        "properties": {
+          "created": {
+            "type": "string"
+          },
+          "updated": {
+            "type": "string"
+          },
+          "deactivated": {
+            "type": "boolean"
+          },
+          "versionId": {
+            "type": "string"
+          },
+          "nextUpdate": {
+            "type": "string"
+          },
+          "nextVersionId": {
+            "type": "string"
+          },
+          "equivalentId": {
+            "type": "string"
+          },
+          "canonicalId": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "DidDocumentMetadata": {
+        "$ref": "#/components/schemas/DIDDocumentMetadata"
+      },
+      "DidResolveSuccessResponse": {
+        "properties": {
+          "didResolutionMetadata": {
+            "$ref": "#/components/schemas/DidResolutionMetadata"
+          },
+          "didDocument": {
+            "$ref": "#/components/schemas/DidDocumentJson"
+          },
+          "didDocumentMetadata": {
+            "$ref": "#/components/schemas/DidDocumentMetadata"
+          }
+        },
+        "required": [
+          "didResolutionMetadata",
+          "didDocument",
+          "didDocumentMetadata"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "DidResolveFailedResponse": {
+        "properties": {
+          "didResolutionMetadata": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DidResolutionMetadata"
+              },
+              {
+                "properties": {
+                  "error": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "error",
+                  "message"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "didDocument": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DidDocumentJson"
+              }
+            ],
+            "nullable": true
+          },
+          "didDocumentMetadata": {
+            "$ref": "#/components/schemas/DidDocumentMetadata"
+          }
+        },
+        "required": [
+          "didResolutionMetadata",
+          "didDocument",
+          "didDocumentMetadata"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "KeyType": {
+        "enum": [
+          "ed25519",
+          "bls12381g1g2",
+          "bls12381g1",
+          "bls12381g2",
+          "x25519",
+          "p256",
+          "p384",
+          "p521",
+          "k256"
+        ],
+        "type": "string"
+      },
+      "PrivateKey": {
+        "properties": {
+          "keyType": {
+            "$ref": "#/components/schemas/KeyType"
+          },
+          "privateKeyBase58": {
+            "type": "string",
+            "description": "Base58 encoded private key"
+          }
+        },
+        "required": [
+          "keyType",
+          "privateKeyBase58"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "DidImportOptions": {
+        "properties": {
+          "did": {
+            "$ref": "#/components/schemas/Did"
+          },
+          "didDocument": {
+            "$ref": "#/components/schemas/DidDocumentJson"
+          },
+          "privateKeys": {
+            "items": {
+              "$ref": "#/components/schemas/PrivateKey"
+            },
+            "type": "array",
+            "description": "Private keys to import as part of the did document"
+          },
+          "overwrite": {
+            "type": "boolean",
+            "description": "Whether to overwrite the existing did document and private keys"
+          }
+        },
+        "required": [
+          "did"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AnyJsonObject": {
+        "description": "JSON object that can contain any key-value pairs",
+        "properties": {},
+        "type": "object",
+        "additionalProperties": false
+      },
+      "DidCreateBaseResponse__state-finished--did-Did--didDocument-DidDocumentJson--secret_63_-AnyJsonObject__": {
+        "properties": {
+          "jobId": {
+            "type": "string"
+          },
+          "didRegistrationMetadata": {
+            "$ref": "#/components/schemas/AnyJsonObject"
+          },
+          "didDocumentMetadata": {
+            "$ref": "#/components/schemas/DidResolutionMetadata"
+          },
+          "didState": {
+            "properties": {
+              "secret": {
+                "$ref": "#/components/schemas/AnyJsonObject"
+              },
+              "didDocument": {
+                "$ref": "#/components/schemas/DidDocumentJson"
+              },
+              "did": {
+                "$ref": "#/components/schemas/Did"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "finished"
+                ],
+                "nullable": false
+              }
+            },
+            "required": [
+              "didDocument",
+              "did",
+              "state"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "didRegistrationMetadata",
+          "didDocumentMetadata",
+          "didState"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "DidCreateFinishedResponse": {
+        "$ref": "#/components/schemas/DidCreateBaseResponse__state-finished--did-Did--didDocument-DidDocumentJson--secret_63_-AnyJsonObject__"
+      },
+      "DidCreateBaseResponse__state-failed--did_63_-Did--didDocument_63_-DidDocumentJson--secret_63_-AnyJsonObject--reason-string__": {
+        "properties": {
+          "jobId": {
+            "type": "string"
+          },
+          "didRegistrationMetadata": {
+            "$ref": "#/components/schemas/AnyJsonObject"
+          },
+          "didDocumentMetadata": {
+            "$ref": "#/components/schemas/DidResolutionMetadata"
+          },
+          "didState": {
+            "properties": {
+              "reason": {
+                "type": "string"
+              },
+              "secret": {
+                "$ref": "#/components/schemas/AnyJsonObject"
+              },
+              "didDocument": {
+                "$ref": "#/components/schemas/DidDocumentJson"
+              },
+              "did": {
+                "$ref": "#/components/schemas/Did"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "failed"
+                ],
+                "nullable": false
+              }
+            },
+            "required": [
+              "reason",
+              "state"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "didRegistrationMetadata",
+          "didDocumentMetadata",
+          "didState"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "DidCreateFailedResponse": {
+        "$ref": "#/components/schemas/DidCreateBaseResponse__state-failed--did_63_-Did--didDocument_63_-DidDocumentJson--secret_63_-AnyJsonObject--reason-string__"
+      },
+      "DidCreateBaseResponse__state-action--action-string--did_63_-Did--didDocument_63_-DidDocumentJson--secret_63_-AnyJsonObject--_91_key-string_93__58_unknown__": {
+        "properties": {
+          "jobId": {
+            "type": "string"
+          },
+          "didRegistrationMetadata": {
+            "$ref": "#/components/schemas/AnyJsonObject"
+          },
+          "didDocumentMetadata": {
+            "$ref": "#/components/schemas/DidResolutionMetadata"
+          },
+          "didState": {
+            "properties": {
+              "secret": {
+                "$ref": "#/components/schemas/AnyJsonObject"
+              },
+              "didDocument": {
+                "$ref": "#/components/schemas/DidDocumentJson"
+              },
+              "did": {
+                "$ref": "#/components/schemas/Did"
+              },
+              "action": {
+                "type": "string"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "action"
+                ],
+                "nullable": false
+              }
+            },
+            "additionalProperties": {},
+            "required": [
+              "action",
+              "state"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "didRegistrationMetadata",
+          "didDocumentMetadata",
+          "didState"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "DidCreateActionResponse": {
+        "$ref": "#/components/schemas/DidCreateBaseResponse__state-action--action-string--did_63_-Did--didDocument_63_-DidDocumentJson--secret_63_-AnyJsonObject--_91_key-string_93__58_unknown__"
+      },
+      "DidCreateBaseResponse__state-wait--did_63_-Did--didDocument_63_-DidDocumentJson--secret_63_-AnyJsonObject__": {
+        "properties": {
+          "jobId": {
+            "type": "string"
+          },
+          "didRegistrationMetadata": {
+            "$ref": "#/components/schemas/AnyJsonObject"
+          },
+          "didDocumentMetadata": {
+            "$ref": "#/components/schemas/DidResolutionMetadata"
+          },
+          "didState": {
+            "properties": {
+              "secret": {
+                "$ref": "#/components/schemas/AnyJsonObject"
+              },
+              "didDocument": {
+                "$ref": "#/components/schemas/DidDocumentJson"
+              },
+              "did": {
+                "$ref": "#/components/schemas/Did"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "wait"
+                ],
+                "nullable": false
+              }
+            },
+            "required": [
+              "state"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "didRegistrationMetadata",
+          "didDocumentMetadata",
+          "didState"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "DidCreateWaitResponse": {
+        "$ref": "#/components/schemas/DidCreateBaseResponse__state-wait--did_63_-Did--didDocument_63_-DidDocumentJson--secret_63_-AnyJsonObject__"
+      },
+      "Pick_DidCreateBaseOptions.Exclude_keyofDidCreateBaseOptions.did-or-didDocument__": {
+        "properties": {
+          "method": {
+            "type": "string"
+          },
+          "options": {
+            "$ref": "#/components/schemas/AnyJsonObject"
+          },
+          "secret": {
+            "$ref": "#/components/schemas/AnyJsonObject"
+          }
+        },
+        "type": "object",
+        "description": "From T, pick a set of properties whose keys are in the union K"
+      },
+      "KeyOrJwkDidCreateOptions": {
+        "properties": {
+          "method": {
+            "type": "string",
+            "enum": [
+              "key",
+              "jwk"
+            ]
+          },
+          "options": {
+            "properties": {
+              "keyType": {
+                "$ref": "#/components/schemas/KeyType"
+              }
+            },
+            "required": [
+              "keyType"
+            ],
+            "type": "object"
+          },
+          "secret": {
+            "properties": {
+              "privateKeyBase58": {
+                "type": "string"
+              },
+              "seedBase58": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "required": [
+          "method",
+          "options"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "DidCreateBaseOptions": {
+        "properties": {
+          "method": {
+            "type": "string"
+          },
+          "did": {
+            "$ref": "#/components/schemas/Did"
+          },
+          "options": {
+            "$ref": "#/components/schemas/AnyJsonObject"
+          },
+          "secret": {
+            "$ref": "#/components/schemas/AnyJsonObject"
+          },
+          "didDocument": {
+            "$ref": "#/components/schemas/DidDocumentJson"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "DidCreateOptions": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/KeyOrJwkDidCreateOptions"
+          },
+          {
+            "$ref": "#/components/schemas/DidCreateBaseOptions"
+          }
+        ]
+      },
+      "AnonCredsSchemaId": {
+        "type": "string"
+      },
+      "AnonCredsSchema": {
+        "properties": {
+          "issuerId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "attrNames": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "issuerId",
+          "name",
+          "version",
+          "attrNames"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AnonCredsGetSchemaSuccessResponse": {
+        "properties": {
+          "schemaId": {
+            "$ref": "#/components/schemas/AnonCredsSchemaId"
+          },
+          "schema": {
+            "$ref": "#/components/schemas/AnonCredsSchema"
+          },
+          "resolutionMetadata": {
+            "$ref": "#/components/schemas/AnyJsonObject"
+          },
+          "schemaMetadata": {
+            "$ref": "#/components/schemas/AnyJsonObject"
+          }
+        },
+        "required": [
+          "schemaId",
+          "schema",
+          "resolutionMetadata",
+          "schemaMetadata"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "Required_AnonCredsResolutionMetadata_": {
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": {},
+        "required": [
+          "error",
+          "message"
+        ],
+        "type": "object",
+        "description": "Make all properties in T required"
+      },
+      "AnonCredsGetSchemaFailedResponse": {
+        "properties": {
+          "schemaId": {
+            "$ref": "#/components/schemas/AnonCredsSchemaId"
+          },
+          "schema": {
+            "$ref": "#/components/schemas/AnonCredsSchema"
+          },
+          "resolutionMetadata": {
+            "$ref": "#/components/schemas/Required_AnonCredsResolutionMetadata_"
+          },
+          "schemaMetadata": {
+            "$ref": "#/components/schemas/AnyJsonObject"
+          }
+        },
+        "required": [
+          "schemaId",
+          "resolutionMetadata",
+          "schemaMetadata"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "RegisterSchemaReturnStateFinished": {
+        "properties": {
+          "state": {
+            "type": "string",
+            "enum": [
+              "finished"
+            ],
+            "nullable": false
+          },
+          "schema": {
+            "$ref": "#/components/schemas/AnonCredsSchema"
+          },
+          "schemaId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "state",
+          "schema",
+          "schemaId"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AnonCredsRegisterSchemaSuccessResponse": {
+        "properties": {
+          "jobId": {
+            "type": "string"
+          },
+          "schemaState": {
+            "$ref": "#/components/schemas/RegisterSchemaReturnStateFinished"
+          },
+          "schemaMetadata": {
+            "$ref": "#/components/schemas/AnyJsonObject"
+          },
+          "registrationMetadata": {
+            "$ref": "#/components/schemas/AnyJsonObject"
+          }
+        },
+        "required": [
+          "schemaState",
+          "schemaMetadata",
+          "registrationMetadata"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "RegisterSchemaReturnStateFailed": {
+        "properties": {
+          "state": {
+            "type": "string",
+            "enum": [
+              "failed"
+            ],
+            "nullable": false
+          },
+          "reason": {
+            "type": "string"
+          },
+          "schema": {
+            "$ref": "#/components/schemas/AnonCredsSchema"
+          },
+          "schemaId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "state",
+          "reason"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AnonCredsRegisterSchemaFailedResponse": {
+        "properties": {
+          "jobId": {
+            "type": "string"
+          },
+          "schemaState": {
+            "$ref": "#/components/schemas/RegisterSchemaReturnStateFailed"
+          },
+          "schemaMetadata": {
+            "$ref": "#/components/schemas/AnyJsonObject"
+          },
+          "registrationMetadata": {
+            "$ref": "#/components/schemas/AnyJsonObject"
+          }
+        },
+        "required": [
+          "schemaState",
+          "schemaMetadata",
+          "registrationMetadata"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "RegisterSchemaReturnStateAction": {
+        "properties": {
+          "state": {
+            "type": "string",
+            "enum": [
+              "action"
+            ],
+            "nullable": false
+          },
+          "action": {
+            "type": "string"
+          },
+          "schema": {
+            "$ref": "#/components/schemas/AnonCredsSchema"
+          },
+          "schemaId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "state",
+          "action",
+          "schema",
+          "schemaId"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AnonCredsRegisterSchemaActionResponse": {
+        "properties": {
+          "jobId": {
+            "type": "string"
+          },
+          "schemaState": {
+            "$ref": "#/components/schemas/RegisterSchemaReturnStateAction"
+          },
+          "schemaMetadata": {
+            "$ref": "#/components/schemas/AnyJsonObject"
+          },
+          "registrationMetadata": {
+            "$ref": "#/components/schemas/AnyJsonObject"
+          }
+        },
+        "required": [
+          "schemaState",
+          "schemaMetadata",
+          "registrationMetadata"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "RegisterSchemaReturnStateWait": {
+        "properties": {
+          "state": {
+            "type": "string",
+            "enum": [
+              "wait"
+            ],
+            "nullable": false
+          },
+          "schema": {
+            "$ref": "#/components/schemas/AnonCredsSchema"
+          },
+          "schemaId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "state"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AnonCredsRegisterSchemaWaitResponse": {
+        "properties": {
+          "jobId": {
+            "type": "string"
+          },
+          "schemaState": {
+            "$ref": "#/components/schemas/RegisterSchemaReturnStateWait"
+          },
+          "schemaMetadata": {
+            "$ref": "#/components/schemas/AnyJsonObject"
+          },
+          "registrationMetadata": {
+            "$ref": "#/components/schemas/AnyJsonObject"
+          }
+        },
+        "required": [
+          "schemaState",
+          "schemaMetadata",
+          "registrationMetadata"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AnonCredsRegisterSchemaBody": {
+        "properties": {
+          "schema": {
+            "$ref": "#/components/schemas/AnonCredsSchema"
+          },
+          "options": {
+            "$ref": "#/components/schemas/AnyJsonObject"
+          }
+        },
+        "required": [
+          "schema"
+        ],
+        "type": "object",
+        "additionalProperties": false,
+        "example": {
+          "schema": {
+            "issuerId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv",
+            "name": "schema-name",
+            "version": "1.0",
+            "attrNames": [
+              "age"
+            ]
+          }
+        }
+      },
+      "AnonCredsCredentialDefinitionId": {
+        "type": "string"
+      },
+      "AnonCredsCredentialDefinition": {
+        "properties": {
+          "issuerId": {
+            "type": "string"
+          },
+          "schemaId": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "CL"
+            ],
+            "nullable": false
+          },
+          "tag": {
+            "type": "string"
+          },
+          "value": {
+            "properties": {
+              "revocation": {},
+              "primary": {
+                "$ref": "#/components/schemas/Record_string.unknown_"
+              }
+            },
+            "required": [
+              "primary"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "issuerId",
+          "schemaId",
+          "type",
+          "tag",
+          "value"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AnonCredsGetCredentialDefinitionSuccessResponse": {
+        "properties": {
+          "credentialDefinitionId": {
+            "$ref": "#/components/schemas/AnonCredsCredentialDefinitionId"
+          },
+          "credentialDefinition": {
+            "$ref": "#/components/schemas/AnonCredsCredentialDefinition"
+          },
+          "resolutionMetadata": {
+            "$ref": "#/components/schemas/AnyJsonObject"
+          },
+          "credentialDefinitionMetadata": {
+            "$ref": "#/components/schemas/AnyJsonObject"
+          }
+        },
+        "required": [
+          "credentialDefinitionId",
+          "credentialDefinition",
+          "resolutionMetadata",
+          "credentialDefinitionMetadata"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AnonCredsGetCredentialDefinitionFailedResponse": {
+        "properties": {
+          "credentialDefinitionId": {
+            "$ref": "#/components/schemas/AnonCredsCredentialDefinitionId"
+          },
+          "credentialDefinition": {
+            "$ref": "#/components/schemas/AnonCredsCredentialDefinition"
+          },
+          "resolutionMetadata": {
+            "$ref": "#/components/schemas/Required_AnonCredsResolutionMetadata_"
+          },
+          "credentialDefinitionMetadata": {
+            "$ref": "#/components/schemas/AnyJsonObject"
+          }
+        },
+        "required": [
+          "credentialDefinitionId",
+          "resolutionMetadata",
+          "credentialDefinitionMetadata"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "RegisterCredentialDefinitionReturnStateFinished": {
+        "properties": {
+          "state": {
+            "type": "string",
+            "enum": [
+              "finished"
+            ],
+            "nullable": false
+          },
+          "credentialDefinition": {
+            "$ref": "#/components/schemas/AnonCredsCredentialDefinition"
+          },
+          "credentialDefinitionId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "state",
+          "credentialDefinition",
+          "credentialDefinitionId"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AnonCredsRegisterCredentialDefinitionSuccessResponse": {
+        "properties": {
+          "jobId": {
+            "type": "string"
+          },
+          "credentialDefinitionState": {
+            "$ref": "#/components/schemas/RegisterCredentialDefinitionReturnStateFinished"
+          },
+          "credentialDefinitionMetadata": {
+            "$ref": "#/components/schemas/AnyJsonObject"
+          },
+          "registrationMetadata": {
+            "$ref": "#/components/schemas/AnyJsonObject"
+          }
+        },
+        "required": [
+          "credentialDefinitionState",
+          "credentialDefinitionMetadata",
+          "registrationMetadata"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "RegisterCredentialDefinitionReturnStateFailed": {
+        "properties": {
+          "state": {
+            "type": "string",
+            "enum": [
+              "failed"
+            ],
+            "nullable": false
+          },
+          "reason": {
+            "type": "string"
+          },
+          "credentialDefinition": {
+            "$ref": "#/components/schemas/AnonCredsCredentialDefinition"
+          },
+          "credentialDefinitionId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "state",
+          "reason"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AnonCredsRegisterCredentialDefinitionFailedResponse": {
+        "properties": {
+          "jobId": {
+            "type": "string"
+          },
+          "credentialDefinitionState": {
+            "$ref": "#/components/schemas/RegisterCredentialDefinitionReturnStateFailed"
+          },
+          "credentialDefinitionMetadata": {
+            "$ref": "#/components/schemas/AnyJsonObject"
+          },
+          "registrationMetadata": {
+            "$ref": "#/components/schemas/AnyJsonObject"
+          }
+        },
+        "required": [
+          "credentialDefinitionState",
+          "credentialDefinitionMetadata",
+          "registrationMetadata"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "RegisterCredentialDefinitionReturnStateAction": {
+        "properties": {
+          "state": {
+            "type": "string",
+            "enum": [
+              "action"
+            ],
+            "nullable": false
+          },
+          "action": {
+            "type": "string"
+          },
+          "credentialDefinitionId": {
+            "type": "string"
+          },
+          "credentialDefinition": {
+            "$ref": "#/components/schemas/AnonCredsCredentialDefinition"
+          }
+        },
+        "required": [
+          "state",
+          "action",
+          "credentialDefinitionId",
+          "credentialDefinition"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AnonCredsRegisterCredentialDefinitionActionResponse": {
+        "properties": {
+          "jobId": {
+            "type": "string"
+          },
+          "credentialDefinitionState": {
+            "$ref": "#/components/schemas/RegisterCredentialDefinitionReturnStateAction"
+          },
+          "credentialDefinitionMetadata": {
+            "$ref": "#/components/schemas/AnyJsonObject"
+          },
+          "registrationMetadata": {
+            "$ref": "#/components/schemas/AnyJsonObject"
+          }
+        },
+        "required": [
+          "credentialDefinitionState",
+          "credentialDefinitionMetadata",
+          "registrationMetadata"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "RegisterCredentialDefinitionReturnStateWait": {
+        "properties": {
+          "state": {
+            "type": "string",
+            "enum": [
+              "wait"
+            ],
+            "nullable": false
+          },
+          "credentialDefinition": {
+            "$ref": "#/components/schemas/AnonCredsCredentialDefinition"
+          },
+          "credentialDefinitionId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "state"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AnonCredsRegisterCredentialDefinitionWaitResponse": {
+        "properties": {
+          "jobId": {
+            "type": "string"
+          },
+          "credentialDefinitionState": {
+            "$ref": "#/components/schemas/RegisterCredentialDefinitionReturnStateWait"
+          },
+          "credentialDefinitionMetadata": {
+            "$ref": "#/components/schemas/AnyJsonObject"
+          },
+          "registrationMetadata": {
+            "$ref": "#/components/schemas/AnyJsonObject"
+          }
+        },
+        "required": [
+          "credentialDefinitionState",
+          "credentialDefinitionMetadata",
+          "registrationMetadata"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AnonCredsRegisterCredentialDefinitionInput": {
+        "properties": {
+          "issuerId": {
+            "type": "string"
+          },
+          "schemaId": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "issuerId",
+          "schemaId",
+          "tag"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AnonCredsRegisterCredentialDefinitionOptions": {
+        "properties": {
+          "supportRevocation": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "supportRevocation"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AnonCredsRegisterCredentialDefinitionBody": {
+        "properties": {
+          "credentialDefinition": {
+            "$ref": "#/components/schemas/AnonCredsRegisterCredentialDefinitionInput"
+          },
+          "options": {
+            "$ref": "#/components/schemas/AnonCredsRegisterCredentialDefinitionOptions"
+          }
+        },
+        "required": [
+          "credentialDefinition",
+          "options"
+        ],
+        "type": "object",
+        "additionalProperties": false,
+        "example": {
+          "credentialDefinition": {
+            "issuerId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv",
+            "schemaId": "did:indy:bcovrin:test:WgWxqztrNooG92RXvxSTWv/anoncreds/v0/SCHEMA/schema-name/1.0",
+            "tag": "definition"
+          },
+          "options": {
+            "supportRevocation": true
+          }
+        }
+      },
+      "DidCommMimeType": {
+        "enum": [
+          "application/ssi-agent-wire",
+          "application/didcomm-envelope-enc"
+        ],
+        "type": "string"
+      },
+      "Pick_ReturnType_AgentConfig-at-toJSON_.Exclude_keyofReturnType_AgentConfig-at-toJSON_.walletConfig-or-logger-or-agentDependencies__": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "connectionImageUrl": {
+            "type": "string"
+          },
+          "endpoints": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "didCommMimeType": {
+            "$ref": "#/components/schemas/DidCommMimeType"
+          },
+          "useDidKeyInProtocols": {
+            "type": "boolean"
+          },
+          "useDidSovPrefixWhereAllowed": {
+            "type": "boolean"
+          },
+          "autoUpdateStorageOnStartup": {
+            "type": "boolean"
+          },
+          "backupBeforeStorageUpdate": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "label"
+        ],
+        "type": "object",
+        "description": "From T, pick a set of properties whose keys are in the union K"
+      },
+      "ApiAgentConfig": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "connectionImageUrl": {
+            "type": "string"
+          },
+          "endpoints": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "didCommMimeType": {
+            "$ref": "#/components/schemas/DidCommMimeType"
+          },
+          "useDidKeyInProtocols": {
+            "type": "boolean"
+          },
+          "useDidSovPrefixWhereAllowed": {
+            "type": "boolean"
+          },
+          "autoUpdateStorageOnStartup": {
+            "type": "boolean"
+          },
+          "backupBeforeStorageUpdate": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "label"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AgentInfo": {
+        "properties": {
+          "config": {
+            "$ref": "#/components/schemas/ApiAgentConfig",
+            "description": "The config of the agent."
+          },
+          "isInitialized": {
+            "type": "boolean",
+            "description": "Whether the agent has been initialized."
+          }
+        },
+        "required": [
+          "config",
+          "isInitialized"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      }
+    },
+    "securitySchemes": {},
+    "parameters": {
+      "tenant": {
+        "in": "header",
+        "name": "x-tenant-id",
+        "description": "Optional header to set the context to a specific tenant. Only needed when the --multi-tenant feature is enabled. Default value is 'default'",
+        "schema": {
+          "type": "string"
+        }
+      }
+    }
+  }
 }

--- a/packages/rest/src/setup/setupApp.ts
+++ b/packages/rest/src/setup/setupApp.ts
@@ -1,6 +1,6 @@
 import type { CredoRestSetupAppConfig } from './CredoRestConfig'
-import type { RequestWithAgent } from '../authentication'
 import type { ApiError } from '../error'
+import type { RequestWithAgent } from '../tenantMiddleware'
 import type { NextFunction, Request, Response } from 'express'
 import type { Server as HttpServer } from 'http'
 import type { Socket } from 'net'

--- a/packages/rest/tsoa.json
+++ b/packages/rest/tsoa.json
@@ -6,11 +6,19 @@
     "name": "Credo REST API",
     "outputDirectory": "src/generated",
     "specVersion": 3,
-    "securityDefinitions": {
-      "tenants": {
-        "type": "apiKey",
-        "name": "x-tenant-id",
-        "in": "header"
+    "specMerging": "recursive",
+    "spec": {
+      "components": {
+        "parameters": {
+          "tenant": {
+            "in": "header",
+            "name": "x-tenant-id",
+            "description": "Optional header to set the context to a specific tenant. Only needed when the --multi-tenant feature is enabled. Default value is 'default'",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
       }
     }
   },
@@ -18,6 +26,6 @@
     "middlewareTemplate": "src/middlewareTemplate.ts.hbs",
     "routesDir": "src/generated",
     "iocModule": "./src/utils/tsyringeTsoaIocContainer",
-    "authenticationModule": "./src/authentication.ts"
+    "authenticationModule": "./src/tenantMiddleware.ts"
   }
 }


### PR DESCRIPTION
Refactors the auth implementation so that it is handled as auth internally (easiest with TSOA), but isn't advertised as auth, every request now has a `x-tenant-id` header param that you can provide

<img width="1440" alt="image" src="https://github.com/openwallet-foundation/credo-ts-ext/assets/23165168/d90acd35-8c3d-40c3-ba2b-dcf9da29e182">

If incorrect x-tenant-id value was provided you will get a bad request error.